### PR TITLE
Fix .gitignore: build -> /build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Gradle
 .gradle
-build
+/build/
+/buildSrc/build/
 
 # IDEA
-out
+/.idea/
+/buildSrc/out/
+/out/


### PR DESCRIPTION
'build' pattern in .gitignore would exclude build folders in all the subfolders.
It might cause unexpected exclusion of files under packages
like io.github.gradlenexus.build...