### PR TITLE
[#7] Configurable retries to close/release requests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -92,6 +92,8 @@ dependencies {
     testImplementation("com.github.tomakehurst:wiremock:2.25.1")
     testImplementation("ru.lanwen.wiremock:wiremock-junit5:1.3.1")
     testImplementation("org.assertj:assertj-core:3.14.0")
+    testImplementation("org.mockito:mockito-junit-jupiter:3.2.4")
+    testImplementation("com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0")
 }
 
 stutter {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -80,9 +80,7 @@ configurations {
 dependencies {
     shadowed("com.squareup.retrofit2:retrofit:2.7.1")
     shadowed("com.squareup.retrofit2:converter-gson:2.7.1")
-    shadowed("io.github.alexo:retrier:0.1") {
-        exclude("org.mockito")  // https://github.com/alexo/retrier/pull/1
-    }
+    shadowed("net.jodah:failsafe:2.3.3")
 
     val nexusStagingPlugin = create("io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.21.2")
     compileOnly(nexusStagingPlugin)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -80,6 +80,9 @@ configurations {
 dependencies {
     shadowed("com.squareup.retrofit2:retrofit:2.7.1")
     shadowed("com.squareup.retrofit2:converter-gson:2.7.1")
+    shadowed("io.github.alexo:retrier:0.1") {
+        exclude("org.mockito")  // https://github.com/alexo/retrier/pull/1
+    }
 
     val nexusStagingPlugin = create("io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.21.2")
     compileOnly(nexusStagingPlugin)
@@ -110,7 +113,9 @@ configurations {
 sourceSets {
     compatTest {
         compileClasspath += sourceSets["test"].output
+        compileClasspath += sourceSets["main"].output
         runtimeClasspath += sourceSets["test"].output
+        runtimeClasspath += sourceSets["main"].output
     }
 }
 

--- a/src/compatTest/kotlin/io/github/gradlenexus/publishplugin/NexusPublishPluginTests.kt
+++ b/src/compatTest/kotlin/io/github/gradlenexus/publishplugin/NexusPublishPluginTests.kt
@@ -836,7 +836,7 @@ class NexusPublishPluginTests {
                         nexusUrl = uri('${server.baseUrl()}')
                         stagingProfileId = '$STAGING_PROFILE_ID'
                         retrying {
-                            maxNumber.set(3)
+                            maxRetries.set(3)
                             delayBetween.set(java.time.Duration.ofMillis(1))
                         }
                     }

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/CloseNexusStagingRepository.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/CloseNexusStagingRepository.kt
@@ -17,6 +17,7 @@
 package io.github.gradlenexus.publishplugin
 
 import io.github.gradlenexus.publishplugin.internal.NexusClient
+import io.github.gradlenexus.publishplugin.internal.StagingRepositoryTransitioner
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
@@ -40,10 +41,9 @@ constructor(objects: ObjectFactory, extension: NexusPublishExtension, repository
     @TaskAction
     fun closeStagingRepo() {
         val client = NexusClient(repository.get().nexusUrl.get(), repository.get().username.orNull, repository.get().password.orNull, clientTimeout.orNull, connectTimeout.orNull)
+        val repositoryTransitioner = StagingRepositoryTransitioner(client, repository.get().retrying.get())
         logger.info("Closing staging repository with id '{}'", stagingRepositoryId.get())
-        client.closeStagingRepository(stagingRepositoryId.get())
-        val readStagingRepository = client.getStagingRepositoryStateById(stagingRepositoryId.get())
-        logger.lifecycle("Read staging repository: $readStagingRepository")
-        // TODO: Broken with real Nexus - waiting for effective execution is also required https://github.com/gradle-nexus/publish-plugin/issues/7
+        repositoryTransitioner.effectivelyClose(stagingRepositoryId.get())
+        logger.info("Repository with id '{}' effectively closed", stagingRepositoryId.get())
     }
 }

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/CloseNexusStagingRepository.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/CloseNexusStagingRepository.kt
@@ -41,7 +41,9 @@ constructor(objects: ObjectFactory, extension: NexusPublishExtension, repository
     fun closeStagingRepo() {
         val client = NexusClient(repository.get().nexusUrl.get(), repository.get().username.orNull, repository.get().password.orNull, clientTimeout.orNull, connectTimeout.orNull)
         logger.info("Closing staging repository with id '{}'", stagingRepositoryId.get())
-        client.closeStagingRepository(stagingRepositoryId.get()) //should be checked by @Input
+        client.closeStagingRepository(stagingRepositoryId.get())
+        val readStagingRepository = client.getStagingRepositoryStateById(stagingRepositoryId.get())
+        logger.lifecycle("Read staging repository: $readStagingRepository")
         // TODO: Broken with real Nexus - waiting for effective execution is also required https://github.com/gradle-nexus/publish-plugin/issues/7
     }
 }

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/CloseNexusStagingRepository.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/CloseNexusStagingRepository.kt
@@ -16,6 +16,7 @@
 
 package io.github.gradlenexus.publishplugin
 
+import io.github.gradlenexus.publishplugin.internal.BasicActionRetrier
 import io.github.gradlenexus.publishplugin.internal.NexusClient
 import io.github.gradlenexus.publishplugin.internal.StagingRepositoryTransitioner
 import org.gradle.api.model.ObjectFactory
@@ -41,7 +42,7 @@ constructor(objects: ObjectFactory, extension: NexusPublishExtension, repository
     @TaskAction
     fun closeStagingRepo() {
         val client = NexusClient(repository.get().nexusUrl.get(), repository.get().username.orNull, repository.get().password.orNull, clientTimeout.orNull, connectTimeout.orNull)
-        val repositoryTransitioner = StagingRepositoryTransitioner(client, repository.get().retrying.get())
+        val repositoryTransitioner = StagingRepositoryTransitioner(client, BasicActionRetrier.retryUntilRepoTransitionIsCompletedRetrier(repository.get().retrying.get()))
         logger.info("Closing staging repository with id '{}'", stagingRepositoryId.get())
         repositoryTransitioner.effectivelyClose(stagingRepositoryId.get())
         logger.info("Repository with id '{}' effectively closed", stagingRepositoryId.get())

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/InitializeNexusStagingRepository.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/InitializeNexusStagingRepository.kt
@@ -80,7 +80,7 @@ constructor(
         var stagingProfileId = repository.get().stagingProfileId.orNull
         if (stagingProfileId == null) {
             val packageGroup = packageGroup.get()
-            logger.debug("No stagingProfileId set, querying for packageGroup '{}'", packageGroup)
+            logger.info("No stagingProfileId set, querying for packageGroup '{}'", packageGroup)
             stagingProfileId = client.findStagingProfileId(packageGroup)
                     ?: throw GradleException("Failed to find staging profile for package group: $packageGroup")
         }

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishExceptions.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishExceptions.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.gradlenexus.publishplugin
+
+import java.lang.RuntimeException
+
+open class NexusPublishException : RuntimeException {
+    constructor(message: String) : super(message)
+    constructor(message: String, cause: Throwable) : super(message, cause)
+}
+
+open class RepositoryTransitionException(message: String) : NexusPublishException(message)

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusRepository.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusRepository.kt
@@ -16,7 +16,6 @@
 
 package io.github.gradlenexus.publishplugin
 
-import groovy.lang.Closure
 import org.gradle.api.Action
 import java.net.URI
 import javax.inject.Inject
@@ -25,7 +24,6 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.Optional
 import org.gradle.kotlin.dsl.property
-import org.gradle.util.ConfigureUtil
 
 @Suppress("UnstableApiUsage")
 open class NexusRepository @Inject constructor(@Input val name: String, project: Project) {
@@ -58,11 +56,6 @@ open class NexusRepository @Inject constructor(@Input val name: String, project:
     }
 
     fun retrying(action: Action<in RetryingConfig>) = action.execute(retrying.get())
-
-    //TODO: Fails anyway with Groovy for "maxNumber = 10" with "Cannot cast object '10' with class 'java.lang.Integer' to class 'org.gradle.api.provider.Property'"
-    fun retrying(closure: Closure<*>) {
-        retrying(ConfigureUtil.configureUsing(closure))
-    }
 
     internal fun capitalizedName(): String {
         return name.capitalize()

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusRepository.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusRepository.kt
@@ -16,12 +16,16 @@
 
 package io.github.gradlenexus.publishplugin
 
+import groovy.lang.Closure
+import org.gradle.api.Action
 import java.net.URI
 import javax.inject.Inject
 import org.gradle.api.Project
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.Optional
 import org.gradle.kotlin.dsl.property
+import org.gradle.util.ConfigureUtil
 
 @Suppress("UnstableApiUsage")
 open class NexusRepository @Inject constructor(@Input val name: String, project: Project) {
@@ -47,6 +51,18 @@ open class NexusRepository @Inject constructor(@Input val name: String, project:
     @Optional
     @Input
     val stagingProfileId = project.objects.property<String>()
+
+    @Nested
+    val retrying = project.objects.property<RetryingConfig>().apply {
+        set(RetryingConfig(project))
+    }
+
+    fun retrying(action: Action<in RetryingConfig>) = action.execute(retrying.get())
+
+    //TODO: Fails anyway with Groovy for "maxNumber = 10" with "Cannot cast object '10' with class 'java.lang.Integer' to class 'org.gradle.api.provider.Property'"
+    fun retrying(closure: Closure<*>) {
+        retrying(ConfigureUtil.configureUsing(closure))
+    }
 
     internal fun capitalizedName(): String {
         return name.capitalize()

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/ReleaseNexusStagingRepository.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/ReleaseNexusStagingRepository.kt
@@ -16,6 +16,7 @@
 
 package io.github.gradlenexus.publishplugin
 
+import io.github.gradlenexus.publishplugin.internal.BasicActionRetrier
 import io.github.gradlenexus.publishplugin.internal.NexusClient
 import io.github.gradlenexus.publishplugin.internal.StagingRepositoryTransitioner
 import org.gradle.api.model.ObjectFactory
@@ -42,7 +43,7 @@ constructor(objects: ObjectFactory, extension: NexusPublishExtension, repository
     @TaskAction
     fun releaseStagingRepo() {
         val client = NexusClient(repository.get().nexusUrl.get(), repository.get().username.orNull, repository.get().password.orNull, clientTimeout.orNull, connectTimeout.orNull)
-        val repositoryTransitioner = StagingRepositoryTransitioner(client, repository.get().retrying.get())
+        val repositoryTransitioner = StagingRepositoryTransitioner(client, BasicActionRetrier.retryUntilRepoTransitionIsCompletedRetrier(repository.get().retrying.get()))
         logger.info("Releasing staging repository with id '{}'", stagingRepositoryId.get())
         repositoryTransitioner.effectivelyRelease(stagingRepositoryId.get())
         logger.info("Repository with id '{}' effectively released", stagingRepositoryId.get())

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/ReleaseNexusStagingRepository.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/ReleaseNexusStagingRepository.kt
@@ -43,6 +43,8 @@ constructor(objects: ObjectFactory, extension: NexusPublishExtension, repository
         val client = NexusClient(repository.get().nexusUrl.get(), repository.get().username.orNull, repository.get().password.orNull, clientTimeout.orNull, connectTimeout.orNull)
         logger.info("Releasing staging repository with id '{}'", stagingRepositoryId.get())
         client.releaseStagingRepository(stagingRepositoryId.get())
+        val readStagingRepository = client.getStagingRepositoryStateById(stagingRepositoryId.get())
+        logger.lifecycle("Read staging repository: $readStagingRepository")
         // TODO: Broken with real Nexus - waiting for effective execution is also required https://github.com/gradle-nexus/publish-plugin/issues/7
     }
 }

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/ReleaseNexusStagingRepository.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/ReleaseNexusStagingRepository.kt
@@ -17,6 +17,7 @@
 package io.github.gradlenexus.publishplugin
 
 import io.github.gradlenexus.publishplugin.internal.NexusClient
+import io.github.gradlenexus.publishplugin.internal.StagingRepositoryTransitioner
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
@@ -41,10 +42,9 @@ constructor(objects: ObjectFactory, extension: NexusPublishExtension, repository
     @TaskAction
     fun releaseStagingRepo() {
         val client = NexusClient(repository.get().nexusUrl.get(), repository.get().username.orNull, repository.get().password.orNull, clientTimeout.orNull, connectTimeout.orNull)
+        val repositoryTransitioner = StagingRepositoryTransitioner(client, repository.get().retrying.get())
         logger.info("Releasing staging repository with id '{}'", stagingRepositoryId.get())
-        client.releaseStagingRepository(stagingRepositoryId.get())
-        val readStagingRepository = client.getStagingRepositoryStateById(stagingRepositoryId.get())
-        logger.lifecycle("Read staging repository: $readStagingRepository")
-        // TODO: Broken with real Nexus - waiting for effective execution is also required https://github.com/gradle-nexus/publish-plugin/issues/7
+        repositoryTransitioner.effectivelyRelease(stagingRepositoryId.get())
+        logger.info("Repository with id '{}' effectively released", stagingRepositoryId.get())
     }
 }

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/RetryingConfig.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/RetryingConfig.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.gradlenexus.publishplugin
+
+import org.gradle.api.Project
+import org.gradle.api.tasks.Internal
+import org.gradle.kotlin.dsl.property
+import java.time.Duration
+import javax.inject.Inject
+
+open class RetryingConfig @Inject constructor(project: Project) {
+
+    companion object {
+        private val DEFAULT_DELAY_BETWEEN_ATTEMPTS = Duration.ofSeconds(5)
+        private const val DEFAULT_MAXIMUM_NUMBER_OF_ATTEMPTS = 30
+    }
+
+    @Internal
+    val maxNumber = project.objects.property<Int>().apply {
+        set(DEFAULT_MAXIMUM_NUMBER_OF_ATTEMPTS)
+    }
+
+    @Internal
+    val delayBetween = project.objects.property<Duration>().apply {
+        set(DEFAULT_DELAY_BETWEEN_ATTEMPTS)
+    }
+}

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/RetryingConfig.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/RetryingConfig.kt
@@ -25,17 +25,17 @@ import javax.inject.Inject
 open class RetryingConfig @Inject constructor(project: Project) {
 
     companion object {
-        private val DEFAULT_DELAY_BETWEEN_ATTEMPTS = Duration.ofSeconds(5)
-        private const val DEFAULT_MAXIMUM_NUMBER_OF_ATTEMPTS = 30
+        private val DEFAULT_DELAY_BETWEEN_RETRIES = Duration.ofSeconds(5)
+        private const val DEFAULT_MAXIMUM_NUMBER_OF_RETRIES = 30
     }
 
     @Internal
-    val maxNumber = project.objects.property<Int>().apply {
-        set(DEFAULT_MAXIMUM_NUMBER_OF_ATTEMPTS)
+    val maxRetries = project.objects.property<Int>().apply {
+        set(DEFAULT_MAXIMUM_NUMBER_OF_RETRIES)
     }
 
     @Internal
     val delayBetween = project.objects.property<Duration>().apply {
-        set(DEFAULT_DELAY_BETWEEN_ATTEMPTS)
+        set(DEFAULT_DELAY_BETWEEN_RETRIES)
     }
 }

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/StagingRepository.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/StagingRepository.kt
@@ -16,9 +16,9 @@
 
 package io.github.gradlenexus.publishplugin
 
-data class StagingRepository constructor(val id: String, val state: RepositoryState, val transitioning: Boolean) {
+data class StagingRepository constructor(val id: String, val state: State, val transitioning: Boolean) {
 
-    enum class RepositoryState {
+    enum class State {
         OPEN,
         CLOSED,
         RELEASED,
@@ -29,7 +29,7 @@ data class StagingRepository constructor(val id: String, val state: RepositorySt
         }
 
         companion object {
-            fun parseString(stateAsString: String): RepositoryState {
+            fun parseString(stateAsString: String): State {
                 try {
                     return valueOf(stateAsString.toUpperCase())
                 } catch (e: IllegalArgumentException) {
@@ -41,7 +41,7 @@ data class StagingRepository constructor(val id: String, val state: RepositorySt
 
     companion object {
         fun notFound(id: String): StagingRepository {
-            return StagingRepository(id, RepositoryState.NOT_FOUND, false)
+            return StagingRepository(id, State.NOT_FOUND, false)
         }
     }
 }

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/StagingRepository.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/StagingRepository.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.gradlenexus.publishplugin
+
+data class StagingRepository constructor(val id: String, val state: RepositoryState, val transitioning: Boolean) {
+
+    enum class RepositoryState {
+        OPEN,
+        CLOSED,
+        RELEASED,
+        NOT_FOUND;
+
+        override fun toString(): String {
+            return name.toLowerCase()
+        }
+
+        companion object {
+            fun parseString(stateAsString: String): RepositoryState {
+                try {
+                    return valueOf(stateAsString.toUpperCase())
+                } catch (e: IllegalArgumentException) {
+                    throw IllegalStateException("Unsupported repository state '$stateAsString'. Supported values: ${values()}")
+                }
+            }
+        }
+    }
+
+    companion object {
+        fun notFound(id: String): StagingRepository {
+            return StagingRepository(id, RepositoryState.NOT_FOUND, false)
+        }
+    }
+}

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/internal/ActionRetrier.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/internal/ActionRetrier.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.gradlenexus.publishplugin.internal
+
+interface ActionRetrier<R> {
+    fun execute(operationToExecuteWithRetrying: () -> R): R
+}

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/internal/BasicActionRetrier.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/internal/BasicActionRetrier.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.gradlenexus.publishplugin.internal
+
+import io.github.alexo.retrier.Retrier
+import io.github.gradlenexus.publishplugin.RetryingConfig
+import io.github.gradlenexus.publishplugin.StagingRepository
+
+open class BasicActionRetrier<R>(retryingConfig: RetryingConfig, stopFunction: (R) -> Boolean) : ActionRetrier<R> {
+
+    @Suppress("UNCHECKED_CAST")
+    private val retrier: Retrier = Retrier.Builder()
+                    .withWaitStrategy(Retrier.Strategies.waitConstantly(retryingConfig.delayBetween.get().toMillis()))
+                    .withStopStrategy(Retrier.Strategies.stopAfter(retryingConfig.maxNumber.get()))
+                    .withResultRetryStrategy(stopFunction as ((Any) -> Boolean))
+                    .build()
+
+    override fun execute(operationToExecuteWithRetrying: () -> R): R {
+        return retrier.execute(operationToExecuteWithRetrying)
+    }
+
+    companion object {
+        fun retryUntilRepoTransitionIsCompletedRetrier(retryingConfig: RetryingConfig): BasicActionRetrier<StagingRepository> {
+            return BasicActionRetrier(retryingConfig) { repo: StagingRepository -> repo.transitioning }
+        }
+    }
+}

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/internal/NexusClient.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/internal/NexusClient.kt
@@ -33,7 +33,7 @@ import retrofit2.http.Headers
 import retrofit2.http.POST
 import retrofit2.http.Path
 
-class NexusClient(private val baseUrl: URI, username: String?, password: String?, timeout: Duration?, connectTimeout: Duration?) {
+open class NexusClient(private val baseUrl: URI, username: String?, password: String?, timeout: Duration?, connectTimeout: Duration?) {
     private val api: NexusApi
 
     init {
@@ -89,14 +89,14 @@ class NexusClient(private val baseUrl: URI, username: String?, password: String?
         return response.body()?.data?.stagedRepositoryId ?: throw RuntimeException("No response body")
     }
 
-    fun closeStagingRepository(stagingRepositoryId: String) {
+    open fun closeStagingRepository(stagingRepositoryId: String) {
         val response = api.closeStagingRepo(Dto(StagingRepositoryToTransit(listOf(stagingRepositoryId), "Closed by io.github.gradle-nexus.publish-plugin Gradle plugin"))).execute()
         if (!response.isSuccessful) {
             throw failure("close staging repository", response)
         }
     }
 
-    fun releaseStagingRepository(stagingRepositoryId: String) {
+    open fun releaseStagingRepository(stagingRepositoryId: String) {
         val response = api.releaseStagingRepo(Dto(StagingRepositoryToTransit(listOf(stagingRepositoryId), "Release by io.github.gradle-nexus.publish-plugin Gradle plugin"))).execute()
         if (!response.isSuccessful) {
             throw failure("release staging repository", response)
@@ -106,7 +106,7 @@ class NexusClient(private val baseUrl: URI, username: String?, password: String?
     fun getStagingRepositoryUri(stagingRepositoryId: String): URI =
             URI.create("${baseUrl.toString().removeSuffix("/")}/staging/deployByRepositoryId/$stagingRepositoryId")
 
-    fun getStagingRepositoryStateById(stagingRepositoryId: String): StagingRepository {
+    open fun getStagingRepositoryStateById(stagingRepositoryId: String): StagingRepository {
         val response = api.getStagingRepoById(stagingRepositoryId).execute()
         if (response.code() == 404 && response.errorBody()?.string()?.contains(stagingRepositoryId) == true) {
             return StagingRepository.notFound(stagingRepositoryId)

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/internal/NexusClient.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/internal/NexusClient.kt
@@ -108,6 +108,9 @@ class NexusClient(private val baseUrl: URI, username: String?, password: String?
 
     fun getStagingRepositoryStateById(stagingRepositoryId: String): StagingRepository {
         val response = api.getStagingRepoById(stagingRepositoryId).execute()
+        if (response.code() == 404 && response.errorBody()?.string()?.contains(stagingRepositoryId) == true) {
+            return StagingRepository.notFound(stagingRepositoryId)
+        }
         if (!response.isSuccessful) {
             throw failure("get staging repository by id", response)
         }
@@ -116,10 +119,10 @@ class NexusClient(private val baseUrl: URI, username: String?, password: String?
             require(stagingRepositoryId == readStagingRepo.repositoryId) {
                 "Unexpected read repository id ($stagingRepositoryId != ${readStagingRepo.repositoryId})"
             }
-            return StagingRepository(readStagingRepo.repositoryId, StagingRepository.RepositoryState.parseString(readStagingRepo.type),
+            return StagingRepository(readStagingRepo.repositoryId, StagingRepository.State.parseString(readStagingRepo.type),
                     readStagingRepo.transitioning)
         } else {
-            return StagingRepository.notFound(stagingRepositoryId)
+            return StagingRepository.notFound(stagingRepositoryId) //Should not happen
         }
     }
 

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/internal/NexusClient.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/internal/NexusClient.kt
@@ -16,6 +16,7 @@
 
 package io.github.gradlenexus.publishplugin.internal
 
+import io.github.gradlenexus.publishplugin.StagingRepository
 import java.io.IOException
 import java.io.UncheckedIOException
 import java.net.URI
@@ -105,6 +106,23 @@ class NexusClient(private val baseUrl: URI, username: String?, password: String?
     fun getStagingRepositoryUri(stagingRepositoryId: String): URI =
             URI.create("${baseUrl.toString().removeSuffix("/")}/staging/deployByRepositoryId/$stagingRepositoryId")
 
+    fun getStagingRepositoryStateById(stagingRepositoryId: String): StagingRepository {
+        val response = api.getStagingRepoById(stagingRepositoryId).execute()
+        if (!response.isSuccessful) {
+            throw failure("get staging repository by id", response)
+        }
+        val readStagingRepo: ReadStagingRepository? = response.body()
+        if (readStagingRepo != null) {
+            require(stagingRepositoryId == readStagingRepo.repositoryId) {
+                "Unexpected read repository id ($stagingRepositoryId != ${readStagingRepo.repositoryId})"
+            }
+            return StagingRepository(readStagingRepo.repositoryId, StagingRepository.RepositoryState.parseString(readStagingRepo.type),
+                    readStagingRepo.transitioning)
+        } else {
+            return StagingRepository.notFound(stagingRepositoryId)
+        }
+    }
+
     // TODO: Cover all API calls with unified error handling (including unexpected IOExceptions)
     private fun failure(action: String, response: Response<*>): RuntimeException {
         var message = "Failed to " + action + ", server responded with status code " + response.code()
@@ -122,7 +140,7 @@ class NexusClient(private val baseUrl: URI, username: String?, password: String?
     private interface NexusApi {
 
         companion object {
-            private const val RELEASE_OPERATION_NAME_IN_NEXUS = "promote" // promote and release use the same operation, used body parameters matter
+            private const val RELEASE_OPERATION_NAME_IN_NEXUS = "promote" // promote and release use the same operation, provided body parameters matter
         }
 
         @get:Headers("Accept: application/json")
@@ -131,15 +149,20 @@ class NexusClient(private val baseUrl: URI, username: String?, password: String?
 
         @Headers("Content-Type: application/json")
         @POST("staging/profiles/{stagingProfileId}/start")
-        fun startStagingRepo(@Path("stagingProfileId") stagingProfileId: String, @Body description: Dto<Description>): Call<Dto<StagingRepository>>
+        fun startStagingRepo(@Path("stagingProfileId") stagingProfileId: String, @Body description: Dto<Description>):
+                Call<Dto<CreatedStagingRepository>>
 
         @Headers("Content-Type: application/json")
         @POST("staging/bulk/close")
-        fun closeStagingRepo(@Body stagingRepositoryToClose: Dto<StagingRepositoryToTransit>): Call<Unit>
+        fun closeStagingRepo(@Body stagingRepoToClose: Dto<StagingRepositoryToTransit>): Call<Unit>
 
         @Headers("Content-Type: application/json")
         @POST("staging/bulk/$RELEASE_OPERATION_NAME_IN_NEXUS")
-        fun releaseStagingRepo(@Body stagingRepositoryToClose: Dto<StagingRepositoryToTransit>): Call<Unit>
+        fun releaseStagingRepo(@Body stagingRepoToClose: Dto<StagingRepositoryToTransit>): Call<Unit>
+
+        @Headers("Accept: application/json")
+        @GET("staging/repository/{stagingRepoId}")
+        fun getStagingRepoById(@Path("stagingRepoId") stagingRepoId: String): Call<ReadStagingRepository>
     }
 
     data class Dto<T>(var data: T)
@@ -148,7 +171,9 @@ class NexusClient(private val baseUrl: URI, username: String?, password: String?
 
     data class Description(val description: String)
 
-    data class StagingRepository(var stagedRepositoryId: String)
+    data class CreatedStagingRepository(var stagedRepositoryId: String)
+
+    data class ReadStagingRepository(var repositoryId: String, var type: String, var transitioning: Boolean)
 
     data class StagingRepositoryToTransit(val stagedRepositoryIds: List<String>, val description: String, val autoDropAfterRelease: Boolean = true)
 }

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/internal/StagingRepositoryTransitioner.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/internal/StagingRepositoryTransitioner.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.gradlenexus.publishplugin.internal
+
+import io.github.alexo.retrier.Retrier
+import io.github.alexo.retrier.Retrier.Strategies.stopAfter
+import io.github.gradlenexus.publishplugin.RetryingConfig
+import io.github.gradlenexus.publishplugin.StagingRepository
+import org.gradle.api.GradleException
+
+//TODO: RetryingConfig pullutes StagingRepositoryTransitioner with Gradle - problematic with unit testing
+class StagingRepositoryTransitioner(val nexusClient: NexusClient, val retryingConfig: RetryingConfig) {
+
+    fun effectivelyClose(repoId: String) {
+        effectivelyChangeState(repoId, StagingRepository.State.CLOSED, nexusClient::closeStagingRepository)
+    }
+
+    fun effectivelyRelease(repoId: String) {
+        effectivelyChangeState(repoId, StagingRepository.State.NOT_FOUND, nexusClient::releaseStagingRepository)
+    }
+
+    private fun effectivelyChangeState(repoId: String, desiredState: StagingRepository.State, transitionClientRequest: (String) -> Unit) {
+        transitionClientRequest.invoke(repoId)
+        val readStagingRepository = createRetrier().execute { getStagingRepositoryStateById(repoId) }
+        assertRepositoryNotTransitioning(readStagingRepository)
+        assertRepositoryInDesiredState(readStagingRepository, desiredState)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun createRetrier(): Retrier {
+        return Retrier.Builder()
+                .withWaitStrategy(Retrier.Strategies.waitConstantly(retryingConfig.delayBetween.get().toMillis()))
+                .withStopStrategy(stopAfter(retryingConfig.maxNumber.get()))
+                .withResultRetryStrategy({ repo: StagingRepository -> repo.transitioning } as ((Any) -> Boolean))
+                .build()
+    }
+
+    private fun getStagingRepositoryStateById(repoId: String): StagingRepository {
+        val readStagingRepository: StagingRepository = nexusClient.getStagingRepositoryStateById(repoId)
+        println("Read staging repository: state: ${readStagingRepository.state}, transitioning: ${readStagingRepository.transitioning}")
+        return readStagingRepository
+    }
+
+    private fun assertRepositoryNotTransitioning(repository: StagingRepository) {
+        if (repository.transitioning) {
+            //TODO: Custom exception type
+            throw GradleException("Staging repository is still transitioning after defined time. Consider its increament. $repository")
+        }
+    }
+
+    private fun assertRepositoryInDesiredState(repository: StagingRepository, desiredState: StagingRepository.State) {
+        if (repository.state != desiredState) {
+            //TODO: Custom exception type
+            throw GradleException("Staging repository is not in desired state ($desiredState): $repository. It is unexpected. Please report it " +
+                    "to https://github.com/gradle-nexus/publish-plugin/issues/ with '--info' logs")
+        }
+    }
+}

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/internal/StagingRepositoryTransitioner.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/internal/StagingRepositoryTransitioner.kt
@@ -38,10 +38,13 @@ class StagingRepositoryTransitioner(val nexusClient: NexusClient, val retrier: A
 
     private fun effectivelyChangeState(repoId: String, desiredState: StagingRepository.State, transitionClientRequest: (String) -> Unit) {
         transitionClientRequest.invoke(repoId)
-        val readStagingRepository = retrier.execute { getStagingRepositoryStateById(repoId) }
+        val readStagingRepository = waitUntilTransitionIsDoneOrTimeoutAndReturnLastRepositoryState(repoId)
         assertRepositoryNotTransitioning(readStagingRepository)
         assertRepositoryInDesiredState(readStagingRepository, desiredState)
     }
+
+    private fun waitUntilTransitionIsDoneOrTimeoutAndReturnLastRepositoryState(repoId: String) =
+            retrier.execute { getStagingRepositoryStateById(repoId) }
 
     private fun getStagingRepositoryStateById(repoId: String): StagingRepository {
         val readStagingRepository: StagingRepository = nexusClient.getStagingRepositoryStateById(repoId)

--- a/src/test/kotlin/io/github/gradlenexus/publishplugin/internal/StagingRepositoryTransitionerTest.kt
+++ b/src/test/kotlin/io/github/gradlenexus/publishplugin/internal/StagingRepositoryTransitionerTest.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.gradlenexus.publishplugin.internal
+
+import com.nhaarman.mockitokotlin2.anyOrNull
+import io.github.gradlenexus.publishplugin.RepositoryTransitionException
+import io.github.gradlenexus.publishplugin.StagingRepository
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.BDDMockito.given
+import org.mockito.Mock
+import org.mockito.Mockito.inOrder
+import org.mockito.invocation.InvocationOnMock
+import org.mockito.junit.jupiter.MockitoExtension
+
+@ExtendWith(MockitoExtension::class)
+internal class StagingRepositoryTransitionerTest {
+
+    companion object {
+        private const val TEST_STAGING_REPO_ID = "orgexample-42"
+    }
+
+    @Mock
+    private lateinit var nexusClient: NexusClient
+    @Mock
+    private lateinit var retrier: ActionRetrier<StagingRepository>
+
+    private lateinit var transitioner: StagingRepositoryTransitioner
+
+    @BeforeEach
+    internal fun setUp() {
+        transitioner = StagingRepositoryTransitioner(nexusClient, retrier)
+    }
+
+    @Test
+    internal fun `request repository close and get its state after execution by retrier`() {
+        given(nexusClient.getStagingRepositoryStateById(TEST_STAGING_REPO_ID))
+                .willReturn(StagingRepository(TEST_STAGING_REPO_ID, StagingRepository.State.CLOSED, false))
+        given(retrier.execute(anyOrNull())).willAnswer(executeFunctionPassedAsFirstArgument())
+
+        transitioner.effectivelyClose(TEST_STAGING_REPO_ID)
+
+        val inOrder = inOrder(nexusClient, retrier)
+        inOrder.verify(nexusClient).closeStagingRepository(TEST_STAGING_REPO_ID)
+        inOrder.verify(nexusClient).getStagingRepositoryStateById(TEST_STAGING_REPO_ID)
+    }
+
+    @Test
+    internal fun `request release repository and get its state after execution by retrier`() {
+        given(nexusClient.getStagingRepositoryStateById(TEST_STAGING_REPO_ID))
+                .willReturn(StagingRepository(TEST_STAGING_REPO_ID, StagingRepository.State.NOT_FOUND, false))
+        given(retrier.execute(anyOrNull())).willAnswer(executeFunctionPassedAsFirstArgument())
+
+        transitioner.effectivelyRelease(TEST_STAGING_REPO_ID)
+
+        val inOrder = inOrder(nexusClient, retrier)
+        inOrder.verify(nexusClient).releaseStagingRepository(TEST_STAGING_REPO_ID)
+        inOrder.verify(nexusClient).getStagingRepositoryStateById(TEST_STAGING_REPO_ID)
+    }
+
+    @Test
+    internal fun `throw meaningful exception on repository still in transition on close`() {
+        given(nexusClient.getStagingRepositoryStateById(TEST_STAGING_REPO_ID))
+                .willReturn(StagingRepository(TEST_STAGING_REPO_ID, StagingRepository.State.CLOSED, true))
+        given(retrier.execute(anyOrNull())).willAnswer(executeFunctionPassedAsFirstArgument())
+
+        assertThatExceptionOfType(RepositoryTransitionException::class.java)
+                .isThrownBy { transitioner.effectivelyClose(TEST_STAGING_REPO_ID) }
+                .withMessageContainingAll(TEST_STAGING_REPO_ID, "transitioning=true")
+    }
+
+    @Test
+    internal fun `throw meaningful exception on repository still in wrong state on close`() {
+        given(nexusClient.getStagingRepositoryStateById(TEST_STAGING_REPO_ID))
+                .willReturn(StagingRepository(TEST_STAGING_REPO_ID, StagingRepository.State.OPEN, false))
+        given(retrier.execute(anyOrNull())).willAnswer(executeFunctionPassedAsFirstArgument())
+
+        assertThatExceptionOfType(RepositoryTransitionException::class.java)
+                .isThrownBy { transitioner.effectivelyClose(TEST_STAGING_REPO_ID) }
+                .withMessageContainingAll(TEST_STAGING_REPO_ID, StagingRepository.State.OPEN.toString(), StagingRepository.State.CLOSED.toString())
+    }
+
+    private fun executeFunctionPassedAsFirstArgument(): (InvocationOnMock) -> StagingRepository {
+        return { invocation: InvocationOnMock ->
+            val passedFunction: () -> StagingRepository = invocation.getArgument(0)
+            passedFunction.invoke()
+        }
+    }
+}


### PR DESCRIPTION
his PR adds retrying on the close and release requests. It is required as Nexus only acknowledge that a given repository has been accepted for transition. With Sonatype Nexus is can take minutes to finish the operation.

I started with a basic external [retrier](https://github.com/alexo/retrier), but separated it to be able to switch to some other (external or in-house implementation if needed or desired).

I also considered this [retrier](https://github.com/ravichaturvedi/retrier) (it seems to only support throwing exceptions to indicate a not successful attempt) and that one for [kotlin](https://github.com/michaelbull/kotlin-retry) (it uses suspended function and I'm not sure how Gradle deals with that in the plugins and in addition it is not in Maven Central nor jCenter). In GNSP, I have a custom implementation (which among others nicely displays subsequent attempts), but I don't know if we want to reinvent a wheel here and maybe some external retrier will be fine.

I was able to successfully release locally a small sample project with the plugin as e2e tests. However, it requires some more work to be able to use it as automatic e2e tests from the CI server (#5). Then it would be good to split also functional tests into smaller pieces.

Btw, I moved MockServer to a field to simplify private method calls - it is used by (almost) everything in that class. It makes a diff less readable. I may revert it and propose as a separate PR, if you prefer.

Closes #7.