### PR TITLE
E2E tests with Sonatype Nexus

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,31 @@
+name: E2E tests
+
+on:
+  push:
+    branches:
+      - master
+      - "szpak/*"
+      - "marc/*"
+
+jobs:
+  gradle:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout project with submodules
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+    - name: Setup JDK 8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 8
+    - name: Run sanity check
+      run: ./gradlew --scan --stacktrace test
+    - name: Run E2E tests
+      env:
+        ORG_GRADLE_PROJECT_sonatypeUsernameE2E: ${{ secrets.SONATYPE_USERNAME_E2E }}
+        ORG_GRADLE_PROJECT_sonatypePasswordE2E: ${{ secrets.SONATYPE_PASSWORD_E2E }}
+        ORG_GRADLE_PROJECT_signingKeyE2E: ${{ secrets.GPG_SIGNING_KEY_E2E }}
+        ORG_GRADLE_PROJECT_signingPasswordE2E: ${{ secrets.GPG_SIGNING_KEY_PASSPHRASE_E2E }}
+      run: |
+        ./gradlew --stacktrace --info e2eTest

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/e2eTest/resources/nexus-publish-e2e-minimal"]
 	path = src/e2eTest/resources/nexus-publish-e2e-minimal
-	url = git@github.com:gradle-nexus-e2e/nexus-publish-e2e-minimal.git
+	url = git@github.com:gradle-nexus/nexus-publish-e2e-minimal.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/e2eTest/resources/nexus-publish-e2e-minimal"]
+	path = src/e2eTest/resources/nexus-publish-e2e-minimal
+	url = git@github.com:gradle-nexus-e2e/nexus-publish-e2e-minimal.git

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -104,6 +104,13 @@ stutter {
     }
 }
 
+val e2eTest by sourceSets.creating {    //separate infrastructure as compatTest is called multiple times with different Java versions
+    compileClasspath += sourceSets["compatTest"].output
+    compileClasspath += sourceSets["main"].output
+    runtimeClasspath += sourceSets["compatTest"].output
+    runtimeClasspath += sourceSets["main"].output
+}
+
 configurations {
     compatTestCompileClasspath {
         extendsFrom(testCompileClasspath.get())
@@ -111,10 +118,10 @@ configurations {
     compatTestRuntimeClasspath {
         extendsFrom(testRuntimeClasspath.get())
     }
-    create("e2eTestCompileClasspath") {
+    configurations.named(e2eTest.implementationConfigurationName) {
         extendsFrom(compatTestCompileClasspath.get())
     }
-    create("e2eTestRuntimeClasspath") {
+    configurations.named(e2eTest.runtimeOnlyConfigurationName) {
         extendsFrom(compatTestRuntimeClasspath.get())
     }
 }
@@ -124,12 +131,6 @@ sourceSets {
         compileClasspath += sourceSets["test"].output
         compileClasspath += sourceSets["main"].output
         runtimeClasspath += sourceSets["test"].output
-        runtimeClasspath += sourceSets["main"].output
-    }
-    create("e2eTest") {     //separate infrastructure as compatTest is called multiple times with different Java versions
-        compileClasspath += sourceSets["compatTest"].output
-        compileClasspath += sourceSets["main"].output
-        runtimeClasspath += sourceSets["compatTest"].output
         runtimeClasspath += sourceSets["main"].output
     }
 }
@@ -157,9 +158,9 @@ tasks {
     register<Test>("e2eTest") {
         description = "Run E2E tests."
         group = "Verification"
-        testClassesDirs = sourceSets.get("e2eTest").output.classesDirs
-        classpath = sourceSets.get("e2eTest").runtimeClasspath
-        listOf("sonatypeUsername", "sonatypePassword", "signing.gnupg.homeDir", "signing.gnupg.keyName", "signing.gnupg.passphrase").forEach {
+        testClassesDirs = e2eTest.output.classesDirs
+        classpath = e2eTest.runtimeClasspath
+        listOf("sonatypeUsername", "sonatypePassword", "signingKey", "signingPassword", "signing.gnupg.homeDir", "signing.gnupg.keyName", "signing.gnupg.passphrase").forEach {
             val e2eName = "${it}E2E"
             if (project.hasProperty(e2eName)) {
                 systemProperties.put("org.gradle.project.$e2eName", project.property(e2eName))

--- a/src/compatTest/kotlin/io/github/gradlenexus/publishplugin/BaseGradleTest.kt
+++ b/src/compatTest/kotlin/io/github/gradlenexus/publishplugin/BaseGradleTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.gradlenexus.publishplugin
+
+import org.assertj.core.api.Assertions
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+
+abstract class BaseGradleTest {
+
+    private val gradleRunner = GradleRunner.create()
+            .withPluginClasspath()
+
+    @TempDir
+    protected lateinit var projectDir: Path
+
+    protected fun run(vararg arguments: String): BuildResult {
+        return gradleRunner(*arguments).build()
+    }
+
+    protected fun gradleRunner(vararg arguments: String): GradleRunner {
+        return gradleRunner
+//                .withDebug(true)
+                .withProjectDir(projectDir.toFile())
+                .withArguments(*arguments, "--stacktrace")
+                .forwardOutput()
+    }
+
+    protected fun assertSuccess(result: BuildResult, taskPath: String) {
+        assertOutcome(result, taskPath, TaskOutcome.SUCCESS)
+    }
+
+    protected fun assertOutcome(result: BuildResult, taskPath: String, outcome: TaskOutcome) {
+        Assertions.assertThat(result.task(taskPath)).describedAs("Task $taskPath")
+                .isNotNull
+                .extracting { it!!.outcome }
+                .isEqualTo(outcome)
+    }
+}

--- a/src/e2eTest/kotlin/io/github/gradlenexus/publishplugin/e2e/NexusPublishE2ETests.kt
+++ b/src/e2eTest/kotlin/io/github/gradlenexus/publishplugin/e2e/NexusPublishE2ETests.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.gradlenexus.publishplugin.e2e
+
+import io.github.gradlenexus.publishplugin.BaseGradleTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.io.File
+
+@Suppress("FunctionName")
+class NexusPublishE2ETests : BaseGradleTest() {
+
+    private var extraParams: Array<String> = arrayOf()
+
+    @BeforeEach
+    internal fun setup() {
+        File("src//e2eTest//resources//nexus-publish-e2e-minimal").copyRecursively(projectDir.toFile())
+    }
+
+    @Test
+    fun `release minimal project to real Sonatype Nexus`() {
+        val result = run("publishToSonatype", "closeSonatypeStagingRepository", "releaseSonatypeStagingRepository", "-i", "--console=verbose", *extraParams)
+        assertSuccess(result, ":publishToSonatype")
+        assertSuccess(result, ":closeSonatypeStagingRepository")
+        assertSuccess(result, ":releaseSonatypeStagingRepository")
+    }
+}


### PR DESCRIPTION
I finally sat down and finished E2E testing with Sonatype Nexus (TestKit is lightly different in behaviors than nebula-test which I used before). There is are artifacts of the [minimal project published to Nexus](https://github.com/gradle-nexus-e2e/nexus-publish-e2e-minimal), the repository is closed and released. It can detect some regressions in the communications with Nexus (or occasionally fail on timeout ;-) ).

There is a [dedicated flow](https://github.com/gradle-nexus/publish-plugin/actions/runs/106832486) in GitHub Actions which executes "unit" and e2e tests (without the Gradle version compatibility tests). I needed to script it slightly, maybe it can be done easier in GH Actions.

The flow on the Sonatype side is constructed that way that on the staging repository close the artifacts are pushed into `/dev/null` instead of the real Maven Central. It should be close to production (however, as it turned out with [MVNCENTRAL-5276](https://issues.sonatype.org/browse/MVNCENTRAL-5276), that "fake" repo doesn't fails on superficial signature files).

A separate Nexus user it used which can't release the plugin itself (just that e2e project). Also the separate set of properties (ending with `E2E`) is used to do not accidentally touch production credentials while running locally. As TestKit hides `~/.gradle/gradle.properties` (nice!), I pass the variables to tests itself. The minimal project can be also executed directly from the console (with `*E2E` properties set locally). Probably it would be good to review the minimal project where most likely something could be simplified.

Fixes #5.