### PR TITLE
Use BuildService on Gradle 6.1+

### DIFF
--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/internal/StagingRepositoryUrlRegistry.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/internal/StagingRepositoryUrlRegistry.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.gradlenexus.publishplugin.internal
+
+import java.net.URI
+import java.util.concurrent.ConcurrentHashMap
+
+class StagingRepositoryUrlRegistry {
+    private val mapping = ConcurrentHashMap<URI, URI>()
+    fun registerIfAbsent(serverUrl: URI, action: (URI) -> URI) = mapping.computeIfAbsent(serverUrl, action)
+    fun clear() = mapping.clear()
+}

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/internal/StagingRepositoryUrlRegistryBuildService.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/internal/StagingRepositoryUrlRegistryBuildService.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.gradlenexus.publishplugin.internal
+
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
+
+abstract class StagingRepositoryUrlRegistryBuildService : BuildService<BuildServiceParameters.None> {
+    val registry = StagingRepositoryUrlRegistry()
+}

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/internal/StaticStagingRepositoryUrlRegistry.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/internal/StaticStagingRepositoryUrlRegistry.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.gradlenexus.publishplugin.internal
+
+object StaticStagingRepositoryUrlRegistry {
+    val registry = StagingRepositoryUrlRegistry()
+}


### PR DESCRIPTION
In order to support Gradle's upcoming configuration cache feature
(formerly known as "instant execution"), we no longer use static state
and a build listener to clear it, but rely on a BuildService instead.