### PR TITLE
[#5] Prefer envVars when passing properties to E2E test

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,7 +8,7 @@ on:
       - "marc/*"
 
 jobs:
-  gradle:
+  single-module-release:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout project with submodules


### PR DESCRIPTION
To do not display their values with --info (as parameters passed to
Gradle executor. Properties with "." cannot be passed that way.
They should be avoided on a CI server.