### PR TITLE
[#33] closeAndRelease* simplified tasks

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,4 +28,4 @@ jobs:
         ORG_GRADLE_PROJECT_signingKeyE2E: ${{ secrets.GPG_SIGNING_KEY_E2E }}
         ORG_GRADLE_PROJECT_signingPasswordE2E: ${{ secrets.GPG_SIGNING_KEY_PASSPHRASE_E2E }}
       run: |
-        ./gradlew --stacktrace --info e2eTest
+        ./gradlew --stacktrace e2eTest

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -183,6 +183,11 @@ tasks {
                 }
             }
         }
+        if (project.findProperty("e2eVerboseOutput") != null && project.findProperty("e2eVerboseOutput") != "false") {
+            testLogging {
+                showStandardStreams = true
+            }
+        }
     }
     withType<Test>().configureEach {
         dependsOn(shadowJar)

--- a/src/e2eTest/kotlin/io/github/gradlenexus/publishplugin/e2e/NexusPublishE2ETests.kt
+++ b/src/e2eTest/kotlin/io/github/gradlenexus/publishplugin/e2e/NexusPublishE2ETests.kt
@@ -31,8 +31,7 @@ class NexusPublishE2ETests : BaseGradleTest() {
 
         val result = run(
                 "publishToSonatype",
-                "closeSonatypeStagingRepository",
-                "releaseSonatypeStagingRepository",
+                "closeAndReleaseSonatypeStagingRepository",
                 "--info",
                 "--console=verbose"
         )

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishPlugin.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishPlugin.kt
@@ -42,7 +42,6 @@ class NexusPublishPlugin : Plugin<Project> {
     companion object {
         //visibility for testing
         const val SIMPLIFIED_CLOSE_AND_RELEASE_TASK_NAME = "closeAndReleaseStagingRepository"
-        const val SIMPLIFIED_LEGACY_CLOSE_AND_RELEASE_TASK_NAME = "closeAndReleaseRepository"
     }
 
     override fun apply(project: Project) {
@@ -126,6 +125,14 @@ class NexusPublishPlugin : Plugin<Project> {
                         }
                         configureTaskDependencies(publishingProject, initializeTask, publishAllTask, closeTask, releaseTask, mavenRepo)
                     }
+                }
+            }
+            if (extension.repositories.size == 1) {
+                val repositoryCapitalizedName = extension.repositories.first().capitalizedName
+                val closeAndReleaseTask = rootProject.tasks.withName<Task>("closeAndRelease${repositoryCapitalizedName}StagingRepository")
+                val closeAndReleaseSimplifiedTask = rootProject.tasks.register<Task>(SIMPLIFIED_CLOSE_AND_RELEASE_TASK_NAME)
+                closeAndReleaseSimplifiedTask.configure {
+                    dependsOn(closeAndReleaseTask)
                 }
             }
         }

--- a/src/test/kotlin/io/github/gradlenexus/publishplugin/TaskOrchestrationTest.kt
+++ b/src/test/kotlin/io/github/gradlenexus/publishplugin/TaskOrchestrationTest.kt
@@ -94,6 +94,28 @@ class TaskOrchestrationTest {
                 .contains("closeSonatypeStagingRepository", "releaseSonatypeStagingRepository")
     }
 
+    @Test
+    internal fun `simplified close and release task without repository name should be available if just one repository is configured`() {
+        initSingleProjectWithDefaultConfiguration()
+
+        val closeAndReleaseTask = getJustOneTaskByNameOrFail(NexusPublishPlugin.SIMPLIFIED_CLOSE_AND_RELEASE_TASK_NAME)
+
+        assertThat(closeAndReleaseTask.taskDependencies.getDependencies(null).map { it.name })
+                .contains("closeAndReleaseSonatypeStagingRepository")
+    }
+
+    @Test
+    internal fun `simplified close and release task should be not available for more defined repositories`() {
+        initSingleProjectWithDefaultConfiguration()
+        project.extensions.configure<NexusPublishExtension> {
+            repositories.create("otherNexus")
+        }
+
+        val simplifiedCloseAndReleaseTasks = project.getTasksByName(NexusPublishPlugin.SIMPLIFIED_CLOSE_AND_RELEASE_TASK_NAME, true)
+
+        assertThat(simplifiedCloseAndReleaseTasks).isEmpty()
+    }
+
     private fun initSingleProjectWithDefaultConfiguration() {
         project.apply(plugin = "java")
         project.apply(plugin = "maven-publish")

--- a/src/test/kotlin/io/github/gradlenexus/publishplugin/TaskOrchestrationTest.kt
+++ b/src/test/kotlin/io/github/gradlenexus/publishplugin/TaskOrchestrationTest.kt
@@ -84,6 +84,16 @@ class TaskOrchestrationTest {
         assertGivenTaskMustRunAfterAnother("releaseSonatypeStagingRepository", "closeSonatypeStagingRepository")
     }
 
+    @Test
+    internal fun `closeAndRelease for given repository should depend on close and release tasks`() {
+        initSingleProjectWithDefaultConfiguration()
+
+        val closeAndReleaseTask = getJustOneTaskByNameOrFail("closeAndReleaseSonatypeStagingRepository")
+
+        assertThat(closeAndReleaseTask.taskDependencies.getDependencies(null).map { it.name })
+                .contains("closeSonatypeStagingRepository", "releaseSonatypeStagingRepository")
+    }
+
     private fun initSingleProjectWithDefaultConfiguration() {
         project.apply(plugin = "java")
         project.apply(plugin = "maven-publish")


### PR DESCRIPTION
This PR adds the following tasks:
 - `closeAndReleaseRepoNameStagingRepository` - for every Nexus repo configured
 - `closeAndReleaseStagingRepository` - for projects with just one Nexus repo configured
-  `closeAndReleaseRepository` - deprecated (legacy) task similar to above intended to make migration from GNSP easier.

Fixed #33.

I also slightly reduced verbosity of E2E tests on a CI server .