### PR TITLE
Improve simplified closeAndRelease task

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,4 +28,4 @@ jobs:
         ORG_GRADLE_PROJECT_signingKeyE2E: ${{ secrets.GPG_SIGNING_KEY_E2E }}
         ORG_GRADLE_PROJECT_signingPasswordE2E: ${{ secrets.GPG_SIGNING_KEY_PASSPHRASE_E2E }}
       run: |
-        ./gradlew --stacktrace e2eTest
+        ./gradlew --stacktrace -Pe2eVerboseOutput e2eTest

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishPlugin.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishPlugin.kt
@@ -127,12 +127,14 @@ class NexusPublishPlugin : Plugin<Project> {
                     }
                 }
             }
-            if (extension.repositories.size == 1) {
-                val repositoryCapitalizedName = extension.repositories.first().capitalizedName
-                val closeAndReleaseTask = rootProject.tasks.withName<Task>("closeAndRelease${repositoryCapitalizedName}StagingRepository")
+            if (extension.repositories.isNotEmpty()) {
                 val closeAndReleaseSimplifiedTask = rootProject.tasks.register<Task>(SIMPLIFIED_CLOSE_AND_RELEASE_TASK_NAME)
-                closeAndReleaseSimplifiedTask.configure {
-                    dependsOn(closeAndReleaseTask)
+                extension.repositories.all {
+                    val repositoryCapitalizedName = this.capitalizedName
+                    val closeAndReleaseTask = rootProject.tasks.withName<Task>("closeAndRelease${repositoryCapitalizedName}StagingRepository")
+                    closeAndReleaseSimplifiedTask.configure {
+                        dependsOn(closeAndReleaseTask)
+                    }
                 }
             }
         }

--- a/src/test/kotlin/io/github/gradlenexus/publishplugin/TaskOrchestrationTest.kt
+++ b/src/test/kotlin/io/github/gradlenexus/publishplugin/TaskOrchestrationTest.kt
@@ -121,6 +121,20 @@ class TaskOrchestrationTest {
                 .contains("closeAndReleaseOtherNexusStagingRepository")
     }
 
+    @Test
+    internal fun `description of simplified closeAndRelease task contains names of all defined Nexus instances`() {
+        initSingleProjectWithDefaultConfiguration()
+        project.extensions.configure<NexusPublishExtension> {
+            repositories.create("otherNexus")
+        }
+
+        val closeAndReleaseTask = getJustOneTaskByNameOrFail(NexusPublishPlugin.SIMPLIFIED_CLOSE_AND_RELEASE_TASK_NAME)
+
+        assertThat(closeAndReleaseTask.description)
+                .contains("sonatype")
+                .contains("otherNexus")
+    }
+
     private fun initSingleProjectWithDefaultConfiguration() {
         project.apply(plugin = "java")
         project.apply(plugin = "maven-publish")


### PR DESCRIPTION
As suggested in #38:
 - depend on all `closeAndRelease*StagingRepository` tasks

As a bonus:
 - display release task descriptions on `gw tasks`

Closes #38.