### PR TITLE
Run E2E tests once a week on CI server

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,6 +1,8 @@
 name: E2E tests
 
 on:
+  schedule:
+    - cron: "0 6 * * MON"
   push:
     branches:
       - master


### PR DESCRIPTION
To detect potential repressions/problems on the Sonatype side.

Based on the [documentation](https://help.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule). I haven't tested it.

Closes #43.