### PR TITLE
Move retrying config from repo to extension and rename

### DIFF
--- a/src/compatTest/kotlin/io/github/gradlenexus/publishplugin/NexusPublishPluginTests.kt
+++ b/src/compatTest/kotlin/io/github/gradlenexus/publishplugin/NexusPublishPluginTests.kt
@@ -709,11 +709,11 @@ class NexusPublishPluginTests {
                         username = 'username'
                         password = 'password'
                         stagingProfileId = '$STAGING_PROFILE_ID'
-                        retrying {
-                            maxRetries.set(3)
-                            delayBetween.set(java.time.Duration.ofMillis(1))
-                        }
                     }
+                }
+                transitionCheckOptions {
+                    maxRetries.set(3)
+                    delayBetween.set(java.time.Duration.ofMillis(1))
                 }
             }
         """)

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/AbstractTransitionNexusStagingRepositoryTask.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/AbstractTransitionNexusStagingRepositoryTask.kt
@@ -27,7 +27,6 @@ import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
-import org.gradle.api.tasks.options.Option
 import org.gradle.kotlin.dsl.property
 
 @Suppress("UnstableApiUsage")
@@ -43,11 +42,6 @@ abstract class AbstractTransitionNexusStagingRepositoryTask(
         set(registry.map {
             it[repository.name].stagingRepositoryId
         })
-    }
-
-    @Option(option = "staging-repository-id", description = "staging repository id to close")
-    fun setStagingRepositoryId(stagingRepositoryId: String) {
-        this.stagingRepositoryId.set(stagingRepositoryId)
     }
 
     @Internal

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/AbstractTransitionNexusStagingRepositoryTask.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/AbstractTransitionNexusStagingRepositoryTask.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.gradlenexus.publishplugin
+
+import io.github.gradlenexus.publishplugin.internal.BasicActionRetrier
+import io.github.gradlenexus.publishplugin.internal.NexusClient
+import io.github.gradlenexus.publishplugin.internal.StagingRepository
+import io.github.gradlenexus.publishplugin.internal.StagingRepositoryDescriptorRegistry
+import io.github.gradlenexus.publishplugin.internal.StagingRepositoryTransitioner
+import org.gradle.api.Action
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.options.Option
+import org.gradle.kotlin.dsl.property
+
+@Suppress("UnstableApiUsage")
+abstract class AbstractTransitionNexusStagingRepositoryTask(
+    objects: ObjectFactory,
+    extension: NexusPublishExtension,
+    repository: NexusRepository,
+    registry: Provider<StagingRepositoryDescriptorRegistry>
+) : AbstractNexusStagingRepositoryTask(objects, extension, repository) {
+
+    @Input
+    val stagingRepositoryId = objects.property<String>().apply {
+        set(registry.map {
+            it[repository.name].stagingRepositoryId
+        })
+    }
+
+    @Option(option = "staging-repository-id", description = "staging repository id to close")
+    fun setStagingRepositoryId(stagingRepositoryId: String) {
+        this.stagingRepositoryId.set(stagingRepositoryId)
+    }
+
+    @Internal
+    val transitionCheckOptions = project.objects.property<TransitionCheckOptions>().apply {
+        set(extension.transitionCheckOptions)
+    }
+
+    fun transitionCheckOptions(action: Action<in TransitionCheckOptions>) = action.execute(transitionCheckOptions.get())
+
+    @TaskAction
+    fun transitionStagingRepo() {
+        val client = NexusClient(
+            repository.get().nexusUrl.get(),
+            repository.get().username.orNull,
+            repository.get().password.orNull,
+            clientTimeout.orNull,
+            connectTimeout.orNull
+        )
+        val retrier = transitionCheckOptions.get().run {
+            BasicActionRetrier(maxRetries.get(), delayBetween.get(), StagingRepository::transitioning)
+        }
+        transitionStagingRepo(StagingRepositoryTransitioner(client, retrier))
+    }
+
+    protected abstract fun transitionStagingRepo(repositoryTransitioner: StagingRepositoryTransitioner)
+}

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/CloseNexusStagingRepository.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/CloseNexusStagingRepository.kt
@@ -20,6 +20,7 @@ import io.github.gradlenexus.publishplugin.internal.StagingRepositoryDescriptorR
 import io.github.gradlenexus.publishplugin.internal.StagingRepositoryTransitioner
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.options.Option
 import javax.inject.Inject
 
 open class CloseNexusStagingRepository @Inject constructor(
@@ -28,6 +29,11 @@ open class CloseNexusStagingRepository @Inject constructor(
     repository: NexusRepository,
     registry: Provider<StagingRepositoryDescriptorRegistry>
 ) : AbstractTransitionNexusStagingRepositoryTask(objects, extension, repository, registry) {
+
+    @Option(option = "staging-repository-id", description = "staging repository id to close")
+    fun setStagingRepositoryId(stagingRepositoryId: String) {
+        this.stagingRepositoryId.set(stagingRepositoryId)
+    }
 
     override fun transitionStagingRepo(repositoryTransitioner: StagingRepositoryTransitioner) {
         logger.info("Closing staging repository with id '{}'", stagingRepositoryId.get())

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/CloseNexusStagingRepository.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/CloseNexusStagingRepository.kt
@@ -16,39 +16,20 @@
 
 package io.github.gradlenexus.publishplugin
 
-import io.github.gradlenexus.publishplugin.internal.BasicActionRetrier
-import io.github.gradlenexus.publishplugin.internal.NexusClient
-import io.github.gradlenexus.publishplugin.internal.StagingRepositoryTransitioner
 import io.github.gradlenexus.publishplugin.internal.StagingRepositoryDescriptorRegistry
+import io.github.gradlenexus.publishplugin.internal.StagingRepositoryTransitioner
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Provider
-import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.TaskAction
-import org.gradle.api.tasks.options.Option
-import org.gradle.kotlin.dsl.property
 import javax.inject.Inject
 
-@Suppress("UnstableApiUsage")
-open class CloseNexusStagingRepository @Inject
-constructor(objects: ObjectFactory, extension: NexusPublishExtension, repository: NexusRepository, registry: Provider<StagingRepositoryDescriptorRegistry>) :
-        AbstractNexusStagingRepositoryTask(objects, extension, repository) {
+open class CloseNexusStagingRepository @Inject constructor(
+    objects: ObjectFactory,
+    extension: NexusPublishExtension,
+    repository: NexusRepository,
+    registry: Provider<StagingRepositoryDescriptorRegistry>
+) : AbstractTransitionNexusStagingRepositoryTask(objects, extension, repository, registry) {
 
-    @Input
-    val stagingRepositoryId = objects.property<String>().apply {
-        set(registry.map {
-            it[repository.name].stagingRepositoryId
-        })
-    }
-
-    @Option(option = "staging-repository-id", description = "staging repository id to close")
-    fun setStagingRepositoryId(stagingRepositoryId: String) {
-        this.stagingRepositoryId.set(stagingRepositoryId)
-    }
-
-    @TaskAction
-    fun closeStagingRepo() {
-        val client = NexusClient(repository.get().nexusUrl.get(), repository.get().username.orNull, repository.get().password.orNull, clientTimeout.orNull, connectTimeout.orNull)
-        val repositoryTransitioner = StagingRepositoryTransitioner(client, BasicActionRetrier.retryUntilRepoTransitionIsCompletedRetrier(repository.get().retrying.get()))
+    override fun transitionStagingRepo(repositoryTransitioner: StagingRepositoryTransitioner) {
         logger.info("Closing staging repository with id '{}'", stagingRepositoryId.get())
         repositoryTransitioner.effectivelyClose(stagingRepositoryId.get(), repositoryDescription.get())
         logger.info("Repository with id '{}' effectively closed", stagingRepositoryId.get())

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/DefaultNexusRepositoryContainer.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/DefaultNexusRepositoryContainer.kt
@@ -17,11 +17,11 @@
 package io.github.gradlenexus.publishplugin
 
 import groovy.lang.Closure
-import java.net.URI
 import org.gradle.api.Action
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.internal.NamedDomainObjectContainerConfigureDelegate
 import org.gradle.util.ConfigureUtil
+import java.net.URI
 
 @Suppress("UnstableApiUsage")
 internal class DefaultNexusRepositoryContainer(delegate: NamedDomainObjectContainer<NexusRepository>) : NexusRepositoryContainer, NamedDomainObjectContainer<NexusRepository> by delegate {

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishExceptions.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishExceptions.kt
@@ -16,8 +16,6 @@
 
 package io.github.gradlenexus.publishplugin
 
-import java.lang.RuntimeException
-
 open class NexusPublishException(message: String) : RuntimeException(message)
 
 open class RepositoryTransitionException(message: String) : NexusPublishException(message)

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishExtension.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishExtension.kt
@@ -16,12 +16,12 @@
 
 package io.github.gradlenexus.publishplugin
 
-import java.time.Duration
 import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.container
 import org.gradle.kotlin.dsl.newInstance
 import org.gradle.kotlin.dsl.property
+import java.time.Duration
 
 @Suppress("UnstableApiUsage")
 open class NexusPublishExtension(project: Project) {
@@ -45,6 +45,10 @@ open class NexusPublishExtension(project: Project) {
     val clientTimeout = project.objects.property<Duration>().value(Duration.ofMinutes(5)) //staging repository initialization can take a few minutes on Sonatype Nexus
 
     val connectTimeout = project.objects.property<Duration>().value(Duration.ofMinutes(1))
+
+    val transitionCheckOptions = project.objects.property<TransitionCheckOptions>().value(TransitionCheckOptions(project.objects))
+
+    fun transitionCheckOptions(action: Action<in TransitionCheckOptions>) = action.execute(transitionCheckOptions.get())
 
     val repositories: NexusRepositoryContainer = DefaultNexusRepositoryContainer(project.container(NexusRepository::class) { name ->
         project.objects.newInstance(NexusRepository::class, name, project)

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishExtension.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishExtension.kt
@@ -44,7 +44,7 @@ open class NexusPublishExtension(project: Project) {
 
     val clientTimeout = project.objects.property<Duration>().value(Duration.ofMinutes(5)) //staging repository initialization can take a few minutes on Sonatype Nexus
 
-    val connectTimeout = project.objects.property<Duration>().value(Duration.ofMinutes(1))
+    val connectTimeout = project.objects.property<Duration>().value(Duration.ofMinutes(5))
 
     val transitionCheckOptions = project.objects.property<TransitionCheckOptions>().value(TransitionCheckOptions(project.objects))
 

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusRepository.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusRepository.kt
@@ -16,14 +16,13 @@
 
 package io.github.gradlenexus.publishplugin
 
-import org.gradle.api.Action
-import java.net.URI
-import javax.inject.Inject
 import org.gradle.api.Project
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.kotlin.dsl.property
+import java.net.URI
+import javax.inject.Inject
 
 @Suppress("UnstableApiUsage")
 open class NexusRepository @Inject constructor(@Input val name: String, project: Project) {
@@ -50,11 +49,6 @@ open class NexusRepository @Inject constructor(@Input val name: String, project:
     @Optional
     @Input
     val stagingProfileId = project.objects.property<String>()
-
-    @Internal
-    val retrying = project.objects.property<RetryingConfig>().value(RetryingConfig(project.objects))
-
-    fun retrying(action: Action<in RetryingConfig>) = action.execute(retrying.get())
 
     @get:Internal
     internal val capitalizedName by lazy { name.capitalize() }

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/ReleaseNexusStagingRepository.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/ReleaseNexusStagingRepository.kt
@@ -20,6 +20,7 @@ import io.github.gradlenexus.publishplugin.internal.StagingRepositoryDescriptorR
 import io.github.gradlenexus.publishplugin.internal.StagingRepositoryTransitioner
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.options.Option
 import javax.inject.Inject
 
 open class ReleaseNexusStagingRepository @Inject constructor(
@@ -28,6 +29,11 @@ open class ReleaseNexusStagingRepository @Inject constructor(
     repository: NexusRepository,
     registry: Provider<StagingRepositoryDescriptorRegistry>
 ) : AbstractTransitionNexusStagingRepositoryTask(objects, extension, repository, registry) {
+
+    @Option(option = "staging-repository-id", description = "staging repository id to release")
+    fun setStagingRepositoryId(stagingRepositoryId: String) {
+        this.stagingRepositoryId.set(stagingRepositoryId)
+    }
 
     override fun transitionStagingRepo(repositoryTransitioner: StagingRepositoryTransitioner) {
         logger.info("Releasing staging repository with id '{}'", stagingRepositoryId.get())

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/TransitionCheckOptions.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/TransitionCheckOptions.kt
@@ -20,9 +20,10 @@ import org.gradle.api.model.ObjectFactory
 import org.gradle.kotlin.dsl.property
 import java.time.Duration
 
+@Suppress("UnstableApiUsage")
 open class TransitionCheckOptions(objects: ObjectFactory) {
 
     val maxRetries = objects.property<Int>().value(60)
 
-    val delayBetween = objects.property<Duration>().value(Duration.ofSeconds(5))
+    val delayBetween = objects.property<Duration>().value(Duration.ofSeconds(10))
 }

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/TransitionCheckOptions.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/TransitionCheckOptions.kt
@@ -20,7 +20,7 @@ import org.gradle.api.model.ObjectFactory
 import org.gradle.kotlin.dsl.property
 import java.time.Duration
 
-open class RetryingConfig constructor(objects: ObjectFactory) {
+open class TransitionCheckOptions(objects: ObjectFactory) {
 
     val maxRetries = objects.property<Int>().value(60)
 

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/internal/NexusClient.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/internal/NexusClient.kt
@@ -16,10 +16,6 @@
 
 package io.github.gradlenexus.publishplugin.internal
 
-import java.io.IOException
-import java.io.UncheckedIOException
-import java.net.URI
-import java.time.Duration
 import okhttp3.Credentials
 import okhttp3.OkHttpClient
 import retrofit2.Call
@@ -31,6 +27,10 @@ import retrofit2.http.GET
 import retrofit2.http.Headers
 import retrofit2.http.POST
 import retrofit2.http.Path
+import java.io.IOException
+import java.io.UncheckedIOException
+import java.net.URI
+import java.time.Duration
 
 open class NexusClient(private val baseUrl: URI, username: String?, password: String?, timeout: Duration?, connectTimeout: Duration?) {
     private val api: NexusApi


### PR DESCRIPTION
To avoid confusion since publishing is not retried, only checking the
repo's status when transitioning `RetryingConfig` is moved from
`NexusRepository` to `NexusPublishExtension` and renamed to
`TransitionCheckOptions`. The options specified in the extension are by
default applied to all close and release tasks but can be overridden on
each task, if need be.

Resolves #20.