### PR TITLE
Make closeAndReleaseStagingRepository always available

### DIFF
--- a/src/test/kotlin/io/github/gradlenexus/publishplugin/KotlinParameterizeTest.kt
+++ b/src/test/kotlin/io/github/gradlenexus/publishplugin/KotlinParameterizeTest.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.gradlenexus.publishplugin
+
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * Change the lifecycle of a test class to [PER_CLASS][TestInstance.Lifecycle.PER_CLASS]
+ * so that parameterized tests can have non-static [MethodSource][org.junit.jupiter.params.provider.MethodSource]
+ * test argument factory methods and can be used in Kotlin tests
+ *
+ * Based on: https://blog.oio.de/2018/11/13/how-to-use-junit-5-methodsource-parameterized-tests-with-kotlin/
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class KotlinParameterizeTest

--- a/src/test/kotlin/io/github/gradlenexus/publishplugin/TaskOrchestrationTest.kt
+++ b/src/test/kotlin/io/github/gradlenexus/publishplugin/TaskOrchestrationTest.kt
@@ -95,7 +95,7 @@ class TaskOrchestrationTest {
     }
 
     @Test
-    internal fun `simplified close and release task without repository name should be not available if no repositories are configured`() {
+    internal fun `simplified close and release task without repository name should be available but trigger nothing if no repositories are configured`() {
         initSingleProjectWithDefaultConfiguration()
         project.extensions.configure<NexusPublishExtension> {
             repositories.clear()
@@ -103,7 +103,8 @@ class TaskOrchestrationTest {
 
         val simplifiedCloseAndReleaseTasks = project.getTasksByName(NexusPublishPlugin.SIMPLIFIED_CLOSE_AND_RELEASE_TASK_NAME, true)
 
-        assertThat(simplifiedCloseAndReleaseTasks).isEmpty()
+        assertThat(simplifiedCloseAndReleaseTasks).hasSize(1)
+        assertThat(simplifiedCloseAndReleaseTasks.first().dependsOn).isEmpty()
     }
 
     @Test

--- a/src/test/kotlin/io/github/gradlenexus/publishplugin/internal/StagingRepositoryTransitionerTest.kt
+++ b/src/test/kotlin/io/github/gradlenexus/publishplugin/internal/StagingRepositoryTransitionerTest.kt
@@ -17,11 +17,11 @@
 package io.github.gradlenexus.publishplugin.internal
 
 import com.nhaarman.mockitokotlin2.anyOrNull
+import io.github.gradlenexus.publishplugin.KotlinParameterizeTest
 import io.github.gradlenexus.publishplugin.RepositoryTransitionException
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
@@ -31,7 +31,7 @@ import org.mockito.Mockito.inOrder
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.junit.jupiter.MockitoExtension
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS) //for non static argument provider
+@KotlinParameterizeTest
 @ExtendWith(MockitoExtension::class)
 internal class StagingRepositoryTransitionerTest {
 


### PR DESCRIPTION
Not just "after evaluate" and also when no Nexus repositories are configured. This makes it easier to hide by power users.

Also removed compatibility method for Gradle 4.x which is not supported anymore and improved task orchestration tests.

@vlsi Does it match your needs?

Fixes #51.
