### PR TITLE
Limit JCenter to dokka and its dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
     id("com.github.johnrengelman.shadow") version "6.1.0"
     id("org.jetbrains.gradle.plugin.idea-ext")
     id("com.github.ben-manes.versions") version "0.38.0"
-    id("org.jetbrains.dokka") version "1.4.30"
+    id("org.jetbrains.dokka") version "1.4.32"
     id("org.ajoberstar.stutter") version "0.6.0"
 }
 
@@ -41,7 +41,6 @@ gradlePlugin {
 
 repositories {
     mavenCentral()
-    jcenter()
 }
 
 val licenseHeaderFile = file("gradle/license-header.txt")


### PR DESCRIPTION
Due to JCenter shut down:
https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/

To be merged after 1.0.0.