### PR TITLE
✨ Get staging profile task

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ You can configure the `connectTimeout` and `clientTimeout` properties on the `ne
 The plugin does the following:
 
 - configure a Maven artifact repository for each repository defined in the `nexusPublishing { repositories { ... } }` block in each subproject that applies the `maven-publish` plugin
+- creates a `retrieve{repository.name.capitalize()}StagingProfile` task that retrieves the staging profile id from the remote Nexus repository. This is a diagnostic task to enable setting the configuration property `stagingProfileId` in  `nexusPublishing { repositories { myRepository { ... } } }`. Specifying the configuration property rather than relying on the API call is considered a performance optimization.  
 - create a `initialize${repository.name.capitalize()}StagingRepository` task that starts a new staging repository in case the project's version does not end with `-SNAPSHOT` (customizable via the `useStaging` property) and sets the URL of the corresponding Maven artifact repository accordingly. In case of a multi-project build, all subprojects with the same `nexusUrl` will use the same staging repository.
 - make all publishing tasks for each configured repository depend on the `initialize${repository.name.capitalize()}StagingRepository` task
 - create a `publishTo${repository.name.capitalize()}` lifecycle task that depends on all publishing tasks for the corresponding Maven artifact repository

--- a/src/compatTest/kotlin/io/github/gradlenexus/publishplugin/MethodScopeWiremockResolver.kt
+++ b/src/compatTest/kotlin/io/github/gradlenexus/publishplugin/MethodScopeWiremockResolver.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.gradlenexus.publishplugin
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import org.junit.jupiter.api.extension.AfterEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.api.extension.ParameterContext
+import org.junit.jupiter.api.extension.ParameterResolver
+import ru.lanwen.wiremock.ext.WiremockResolver
+import java.lang.IllegalArgumentException
+
+/**
+ * Composes a [WiremockResolver] and uses that by default. But, if a parameter is annotated
+ * with [MethodScopeWiremockResolver] it creates a new instance of the [WiremockResolver] extension and
+ * manages its lifecycle in the scope of that [ExtensionContext]
+ */
+class MethodScopeWiremockResolver(
+    private val inner: WiremockResolver = WiremockResolver()
+) : ParameterResolver by inner, AfterEachCallback {
+
+    /**
+     * Checks to see if a method the parameter is annotated with [MethodScopedWiremockServer]. If it is, we first verify
+     */
+    override fun resolveParameter(parameterContext: ParameterContext, extensionContext: ExtensionContext): Any {
+        return if (parameterContext.isAnnotated(MethodScopedWiremockServer::class.java)) {
+            if (!parameterContext.parameter.type.isAssignableFrom(WireMockServer::class.java)) {
+                throw IllegalArgumentException("Annotated type must be a WireMockServer")
+            }
+            return getStore(extensionContext)
+                .getOrComputeIfAbsent(Keys.LOCAL_RESOLVER, { WiremockResolver() }, WiremockResolver::class.java)
+                .resolveParameter(parameterContext, extensionContext)
+        } else {
+            inner.resolveParameter(parameterContext, extensionContext)
+        }
+    }
+
+    override fun afterEach(context: ExtensionContext) {
+        getStore(context).get(Keys.LOCAL_RESOLVER, WiremockResolver::class.java)?.afterEach(context)
+        inner.afterEach(context)
+    }
+
+    /**
+     * helper method for get getting a [ExtensionContext.Store] specific to a test method
+     */
+    private fun getStore(context: ExtensionContext): ExtensionContext.Store {
+        return context.getStore(ExtensionContext.Namespace.create(javaClass))
+    }
+
+    /**
+     * Keys for storing and accessing [MethodScopeWiremockResolver]s
+     */
+    enum class Keys {
+        LOCAL_RESOLVER
+    }
+
+    /**
+     * Decorates a parameter also annotated with [WiremockResolver.Wiremock]
+     */
+    @Target(allowedTargets = [AnnotationTarget.VALUE_PARAMETER])
+    @Retention(AnnotationRetention.RUNTIME)
+    annotation class MethodScopedWiremockServer
+}

--- a/src/compatTest/kotlin/io/github/gradlenexus/publishplugin/NexusPublishPluginTests.kt
+++ b/src/compatTest/kotlin/io/github/gradlenexus/publishplugin/NexusPublishPluginTests.kt
@@ -48,13 +48,12 @@ import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.io.TempDir
-import ru.lanwen.wiremock.ext.WiremockResolver
 import ru.lanwen.wiremock.ext.WiremockResolver.Wiremock
 import java.nio.file.Files
 import java.nio.file.Path
 
 @Suppress("FunctionName") // TODO: How to suppress "kotlin:S100" from SonarLint?
-@ExtendWith(WiremockResolver::class)
+@ExtendWith(MethodScopeWiremockResolver::class)
 class NexusPublishPluginTests {
 
     companion object {
@@ -233,9 +232,7 @@ class NexusPublishPluginTests {
     }
 
     @Test
-    fun `publishes to two Nexus repositories`() {
-        val otherServer = WireMockServer()
-        otherServer.start()
+    fun `publishes to two Nexus repositories`(@MethodScopeWiremockResolver.MethodScopedWiremockServer @Wiremock otherServer: WireMockServer) {
         projectDir.resolve("settings.gradle").write("""
             rootProject.name = 'sample'
         """)

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishPlugin.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishPlugin.kt
@@ -68,6 +68,7 @@ class NexusPublishPlugin : Plugin<Project> {
     private fun configureNexusTasks(rootProject: Project, extension: NexusPublishExtension, registry: Provider<StagingRepositoryDescriptorRegistry>) {
         extension.repositories.all {
             val repository = this
+            val retrieveStagingProfileTask = rootProject.tasks.register<RetrieveStagingProfile>("retrieve${capitalizedName}StagingProfile", rootProject.objects, extension, repository)
             val initializeTask = rootProject.tasks.register<InitializeNexusStagingRepository>(
                     "initialize${capitalizedName}StagingRepository", rootProject.objects, extension, repository, registry)
             val closeTask = rootProject.tasks.register<CloseNexusStagingRepository>(
@@ -76,6 +77,9 @@ class NexusPublishPlugin : Plugin<Project> {
                     "release${capitalizedName}StagingRepository", rootProject.objects, extension, repository, registry)
             val closeAndReleaseTask = rootProject.tasks.register<Task>(
                     "closeAndRelease${capitalizedName}StagingRepository")
+            retrieveStagingProfileTask {
+                description = "Gets and displays a staging profile id for a given repository and package group. This is a diagnostic task to get the value and put it into the NexusRepository configuration closure as stagingProfileId."
+            }
             closeTask {
                 description = "Closes open staging repository in '${repository.name}' Nexus instance."
                 group = PublishingPlugin.PUBLISH_TASK_GROUP

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/RetrieveStagingProfile.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/RetrieveStagingProfile.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.gradlenexus.publishplugin
+
+import io.github.gradlenexus.publishplugin.internal.NexusClient
+import org.gradle.api.GradleException
+import org.gradle.api.Incubating
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import org.gradle.kotlin.dsl.property
+import javax.inject.Inject
+
+/**
+ * Diagnostic task for retrieving the [NexusRepository.stagingProfileId] for the [packageGroup] from the provided [NexusRepository] and logging it
+ */
+@Incubating
+open class RetrieveStagingProfile @Inject constructor(
+    objects: ObjectFactory,
+    extension: NexusPublishExtension,
+    repository: NexusRepository
+) : AbstractNexusStagingRepositoryTask(objects, extension, repository) {
+
+    @Input
+    val packageGroup = objects.property<String>().apply {
+        set(extension.packageGroup)
+    }
+
+    @TaskAction
+    fun retrieveStagingProfile() {
+        val repository = repository.get()
+
+        val client = NexusClient(
+            repository.nexusUrl.get(),
+            repository.username.orNull,
+            repository.password.orNull,
+            clientTimeout.orNull,
+            connectTimeout.orNull
+        )
+
+        val packageGroup = packageGroup.get()
+        val stagingProfileId = client.findStagingProfileId(packageGroup)
+            ?: throw GradleException("Failed to find staging profile for package group: $packageGroup")
+        logger.lifecycle("Received staging profile id: '{}' for package {}", stagingProfileId, packageGroup)
+    }
+}


### PR DESCRIPTION
Closes #60 

## Documentation Updates
I think we should add an update to the "Tasks" section of the migration guide to say something like 

```bash
./gradlew getStagingProfile
```

↓

```bash
./gradlew retrieveSonatypeStagingProfile
```

This reflects the main difference between the previous plugin project and this one: tasks are on a per `NexusRepsitory` basis, including the `RetrieveStagingProfile` task. 


## Summary of changes
First adds a new `AbstractNexusStagingRepositoryTask` subclass called `RetrieveStagingProfile`. we register a new `RetrieveStagingProfile` task for each `NexusRepository` registered in the plugin's extension. This enables users to run 
`./gradlew retrieve<NEXUS_REPOSITORY_NAME>StagingProfile` and see the staging profile ID for the repository in stdout. 

~This was initially as far as I was planning on going with this, but something @szpak mentioned in issue #60 caught my attention~
>  Or maybe there should be also an @Output field set to allow others to read it (but I'm not sure why anyone would like to consume that)

~After reading this, it struck me that we wouldn't want there to be inconsistencies between how  `GetStagingProfile` gets the staging profile and how `InitializeNexusStagingRepository` gets the staging profile. So, I went about a small refactor of the plugin to remove the responsibility of figuring out the staging profile id from `InitializeNexusStagingRepository` and instead make it a required input. Then, I configured `InitializeNexusStagingRepository` to depend on the `GetStagingProfile` which now has all the logic for getting the staging profile ID, outputting it to stdout, storing the ID in a file in the build directory, and managing the optimization of not doing the API lookup if the staging profile id is provided via configuration.~

~This not only has benefits for code re-use, but it also helps those who don't configure the stagingProfileId ever. Since we output the staging profile ID to an artifact, it can be cached and reused on subsequent builds which decreases the configuration burden on the user while still giving them access to this performance optimization.~

~I know changing `InitializeNexusStagingRepository` was not technically in the scope of what was discussed in #60 so if you would like me to remove it from the scope of this change I'd be happy to. But, it seemed to me like refactoring `InitializeNexusStagingRepository` was the responsible thing to do as I was introducing some logic duplication around how this plugin gets the staging profile id.~

Update on 2/27/21: After discussion, it was deemed that this refactor was problematic due to the conflicting nature of the different use cases of the `InitializeNexusStagingRepository` task and the diagnostic task to retrieve the staging profile


### Possible other tasks
Another thought that occurred to me was adding a task called `getStagingProfiles` or `getAllStagingProfiles` which is simply an alias for executing `get<NEXUS_REPOSITORY_NAME>StagingProfile` on each configured `NexusRepository`. I ultimately decided it was not worthwhile/might cause confusion but I'm willing to reconsider. 

### Testing gaps?
After writing up this pull request description, I realized my implementation for storing the staging repository ID was flawed, as I at first would overwrite the file storing the staging profile ID every time a new `GetStagingProfile` was run, which could lead to confusing results with multiple  `NexusRepository` destinations. The existing tests didn't catch it because there were no tests that published to two different repositories at the same time. I had to make some tweaks to the helper methods to accomplish this test, but I'm super open to feedback on how this was tested. Perhaps it would be better as a unit test than a compatTest?