### PR TITLE
Display HTTP error response to the user

### DIFF
--- a/src/compatTest/kotlin/io/github/gradlenexus/publishplugin/NexusPublishPluginTests.kt
+++ b/src/compatTest/kotlin/io/github/gradlenexus/publishplugin/NexusPublishPluginTests.kt
@@ -270,6 +270,7 @@ class NexusPublishPluginTests {
         val result = runAndFail("publishToMyNexus")
 
         assertFailure(result, ":initializeMyNexusStagingRepository")
+        assertThat(result.output).contains("status code 404")
         assertThat(result.output).contains("""{"failure":"message"}""")
     }
 

--- a/src/compatTest/kotlin/io/github/gradlenexus/publishplugin/NexusPublishPluginTests.kt
+++ b/src/compatTest/kotlin/io/github/gradlenexus/publishplugin/NexusPublishPluginTests.kt
@@ -854,7 +854,7 @@ class NexusPublishPluginTests {
     }
 
     private fun run(vararg arguments: String): BuildResult =
-         gradleRunner(*arguments).build()
+        gradleRunner(*arguments).build()
 
     private fun runAndFail(vararg arguments: String): BuildResult =
         gradleRunner(*arguments).buildAndFail()

--- a/src/compatTest/kotlin/io/github/gradlenexus/publishplugin/NexusPublishPluginTests.kt
+++ b/src/compatTest/kotlin/io/github/gradlenexus/publishplugin/NexusPublishPluginTests.kt
@@ -24,6 +24,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.get
 import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
 import com.github.tomakehurst.wiremock.client.WireMock.matching
 import com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath
+import com.github.tomakehurst.wiremock.client.WireMock.notFound
 import com.github.tomakehurst.wiremock.client.WireMock.post
 import com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor
 import com.github.tomakehurst.wiremock.client.WireMock.put
@@ -229,6 +230,47 @@ class NexusPublishPluginTests {
                 .withRequestBody(matchingJsonPath("\$.data[?(@.description == 'org.example:sample:0.0.1')]")))
         assertUploadedToStagingRepo("/org/example/sample/0.0.1/sample-0.0.1.pom")
         assertUploadedToStagingRepo("/org/example/sample/0.0.1/sample-0.0.1.jar")
+    }
+
+    @Test
+    fun `displays the error response to the user when a request fails`() {
+        projectDir.resolve("settings.gradle").write("""
+            rootProject.name = 'sample'
+        """)
+        projectDir.resolve("build.gradle").write("""
+            plugins {
+                id('java-library')
+                id('maven-publish')
+                id('io.github.gradle-nexus.publish-plugin')
+            }
+            group = 'org.example'
+            version = '0.0.1'
+            publishing {
+                publications {
+                    mavenJava(MavenPublication) {
+                        from(components.java)
+                    }
+                }
+            }
+            nexusPublishing {
+                repositories {
+                    myNexus {
+                        nexusUrl = uri('${server.baseUrl()}')
+                        snapshotRepositoryUrl = uri('${server.baseUrl()}/snapshots/')
+                        allowInsecureProtocol = true
+                        username = 'username'
+                        password = 'password'
+                    }
+                }
+            }
+        """)
+
+        stubMissingStagingProfileRequest("/staging/profiles")
+
+        val result = runAndFail("publishToMyNexus")
+
+        assertFailure(result, ":initializeMyNexusStagingRepository")
+        assertThat(result.output).contains("""{"failure":"message"}""")
     }
 
     @Test
@@ -810,9 +852,11 @@ class NexusPublishPluginTests {
         """)
     }
 
-    private fun run(vararg arguments: String): BuildResult {
-        return gradleRunner(*arguments).build()
-    }
+    private fun run(vararg arguments: String): BuildResult =
+         gradleRunner(*arguments).build()
+
+    private fun runAndFail(vararg arguments: String): BuildResult =
+        gradleRunner(*arguments).buildAndFail()
 
     private fun gradleRunner(vararg arguments: String): GradleRunner {
         return gradleRunner
@@ -831,6 +875,12 @@ class NexusPublishPluginTests {
         wireMockServer.stubFor(get(urlEqualTo(url))
                 .withHeader("User-Agent", matching("gradle-nexus-publish-plugin/.*"))
                 .willReturn(aResponse().withBody(gson.toJson(mapOf("data" to listOf(*stagingProfiles))))))
+    }
+
+    private fun stubMissingStagingProfileRequest(url: String, wireMockServer: WireMockServer = server) {
+        wireMockServer.stubFor(get(urlEqualTo(url))
+                .withHeader("User-Agent", matching("gradle-nexus-publish-plugin/.*"))
+                .willReturn(notFound().withBody(gson.toJson(mapOf("failure" to "message")))))
     }
 
     private fun stubCreateStagingRepoRequest(url: String, stagedRepositoryId: String, wireMockServer: WireMockServer = server) {
@@ -901,6 +951,10 @@ class NexusPublishPluginTests {
 
     private fun assertSuccess(result: BuildResult, taskPath: String) {
         assertOutcome(result, taskPath, SUCCESS)
+    }
+
+    private fun assertFailure(result: BuildResult, taskPath: String) {
+        assertOutcome(result, taskPath, FAILED)
     }
 
     private fun assertSkipped(result: BuildResult, taskPath: String) {

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/internal/NexusClient.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/internal/NexusClient.kt
@@ -133,11 +133,11 @@ open class NexusClient(private val baseUrl: URI, username: String?, password: St
     private fun failure(action: String, response: Response<*>): RuntimeException {
         var message = "Failed to $action, server at $baseUrl responded with status code ${response.code()}"
         val errorBody = response.errorBody()
-        if (errorBody != null && errorBody.contentLength() > 0) {
+        if (errorBody != null) {
             message += try {
                 ", body: ${errorBody.string()}"
             } catch (exception: IOException) {
-                ", body: (error during read body of error response, message: ${exception.message})"
+                ", body: <error while reading body of error response, message: ${exception.message}>"
             }
         }
         return RuntimeException(message)

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/internal/NexusClient.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/internal/NexusClient.kt
@@ -134,10 +134,10 @@ open class NexusClient(private val baseUrl: URI, username: String?, password: St
         var message = "Failed to $action, server at $baseUrl responded with status code ${response.code()}"
         val errorBody = response.errorBody()
         if (errorBody != null && errorBody.contentLength() > 0) {
-            try {
-                message += ", body: $errorBody"
-            } catch (e: IOException) {
-                throw UncheckedIOException("Failed to read body of error response", e)
+            message += try {
+                ", body: ${errorBody.string()}"
+            } catch (exception: IOException) {
+                ", body: (error during read body of error response, message: ${exception.message})"
             }
         }
         return RuntimeException(message)

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/internal/NexusClient.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/internal/NexusClient.kt
@@ -28,7 +28,6 @@ import retrofit2.http.Headers
 import retrofit2.http.POST
 import retrofit2.http.Path
 import java.io.IOException
-import java.io.UncheckedIOException
 import java.net.URI
 import java.time.Duration
 


### PR DESCRIPTION
Fixes https://github.com/gradle-nexus/publish-plugin/issues/91

This PR logs the (error) response body in the Exception thrown by the plugin whenever a HTTP response fails. This allows the user to fix the problem indicated by the Nexus server.