### PR TITLE
Replace ConfigureUtil.configureSelf with configureEach

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ version = "1.0.0"
 
 ### Publishing to Maven Central via Sonatype OSSRH
 
-In order to publish to Maven Central (aka the Central Repository or just Central) via Sonatype's OSSRH Nexus, you simply need to add the `sonatype()` repository like in the example below. Its `nexusUrl` and `snapshotRepositoryUrl` values are pre-configured.
+In order to publish to Maven Central (aka the Central Repository or just Central) via Sonatype's OSSRH Nexus, you simply need to add the `sonatype` repository like in the example below. Its `nexusUrl` and `snapshotRepositoryUrl` values are pre-configured.
 
 ```groovy
 nexusPublishing {
     repositories {
-        sonatype()
+        sonatype
     }
 }
 ```

--- a/src/compatTest/kotlin/io/github/gradlenexus/publishplugin/NexusPublishPluginTests.kt
+++ b/src/compatTest/kotlin/io/github/gradlenexus/publishplugin/NexusPublishPluginTests.kt
@@ -612,7 +612,7 @@ class NexusPublishPluginTests {
             }
             nexusPublishing {
                 repositories {
-                    sonatype()
+                    sonatype
                 }
             }
             """

--- a/src/compatTest/kotlin/io/github/gradlenexus/publishplugin/NexusPublishPluginTests.kt
+++ b/src/compatTest/kotlin/io/github/gradlenexus/publishplugin/NexusPublishPluginTests.kt
@@ -645,7 +645,41 @@ class NexusPublishPluginTests {
             }
             nexusPublishing {
                 repositories {
-                    sonatype()
+                    sonatype
+                }
+            }
+            """
+        )
+
+        val result = run("printSonatypeConfig")
+
+        assertThat(result.output)
+            .contains("nexusUrl = https://oss.sonatype.org/service/local/")
+            .contains("snapshotRepositoryUrl = https://oss.sonatype.org/content/repositories/snapshots/")
+    }
+
+    @Test
+    fun `uses default URLs for sonatype repos in Kotlin DSL with curly braces`() {
+        projectDir.resolve("settings.gradle").write(
+            """
+            rootProject.name = 'sample'
+            """
+        )
+        projectDir.resolve("build.gradle.kts").write(
+            """
+            plugins {
+                id("io.github.gradle-nexus.publish-plugin")
+            }
+            tasks.create("printSonatypeConfig") {
+                doFirst {
+                    println("nexusUrl = ${"$"}{nexusPublishing.repositories["sonatype"].nexusUrl.orNull}")
+                    println("snapshotRepositoryUrl = ${"$"}{nexusPublishing.repositories["sonatype"].snapshotRepositoryUrl.orNull}")
+                }
+            }
+            nexusPublishing {
+                repositories {
+                    sonatype {
+                    }
                 }
             }
             """

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/DefaultNexusRepositoryContainer.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/DefaultNexusRepositoryContainer.kt
@@ -16,7 +16,6 @@
 
 package io.github.gradlenexus.publishplugin
 
-import org.gradle.api.Action
 import org.gradle.api.NamedDomainObjectContainer
 import java.net.URI
 import javax.inject.Inject
@@ -37,11 +36,5 @@ internal open class DefaultNexusRepositoryContainer @Inject constructor(
                 snapshotRepositoryUrl.set(URI.create("https://oss.sonatype.org/content/repositories/snapshots/"))
             }
         }
-    }
-
-    override fun sonatype(): NexusRepository = sonatype {}
-
-    override fun sonatype(action: Action<in NexusRepository>): NexusRepository = create("sonatype") {
-        action.execute(this)
     }
 }

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusRepositoryContainer.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusRepositoryContainer.kt
@@ -18,8 +18,21 @@ package io.github.gradlenexus.publishplugin
 
 import org.gradle.api.Action
 import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.api.NamedDomainObjectProvider
 
 interface NexusRepositoryContainer : NamedDomainObjectContainer<NexusRepository> {
-    fun sonatype(): NexusRepository
-    fun sonatype(action: Action<in NexusRepository>): NexusRepository
+    val sonatype: NamedDomainObjectProvider<out NexusRepository>
+        get() =
+            // See https://github.com/gradle/gradle/issues/8057#issuecomment-826933995, Introduce TaskContainer.maybeNamed
+            if ("sonatype" in names) {
+                named("sonatype")
+            } else {
+                register("sonatype")
+            }
+
+    @Deprecated("Use sonatype property instead", ReplaceWith("sonatype"))
+    fun sonatype(): NexusRepository = sonatype.get()
+
+    fun sonatype(action: Action<in NexusRepository>): NexusRepository =
+        sonatype.get().apply { action.execute(this) }
 }

--- a/src/test/kotlin/io/github/gradlenexus/publishplugin/TaskOrchestrationTest.kt
+++ b/src/test/kotlin/io/github/gradlenexus/publishplugin/TaskOrchestrationTest.kt
@@ -140,7 +140,7 @@ class TaskOrchestrationTest {
         project.apply(plugin = "maven-publish")
         project.apply<NexusPublishPlugin>()
         project.extensions.configure<NexusPublishExtension> {
-            repositories.sonatype()
+            repositories.sonatype
         }
         project.extensions.configure<PublishingExtension> {
             publications.create<MavenPublication>("mavenJava") {


### PR DESCRIPTION
An extra bonus is that it would transparently support create("sonatype") in Kotlin DSL as well

Fixes https://github.com/gradle-nexus/publish-plugin/issues/152