### PR TITLE
Cron tests with latest Gradle version(s) on CI

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,8 +13,11 @@ max_line_length = off
 trim_trailing_whitespace = true
 # Trailing comma language feature requires Kotlin plugin 1.4+, at the moment the compilation is done with Kotlin 1.3.
 # This helps IDEA to format the code properly, see also spotless { } in build.gradle.kts.
-ij_kotlin_allow_trailing_comma = false # Only used for declaration site 
+ij_kotlin_allow_trailing_comma = false # Only used for declaration site
 ij_kotlin_allow_trailing_comma_on_call_site = false
 
 [*.bat]
 end_of_line = crlf
+
+[*.yml]
+indent_size = 2

--- a/.github/workflows/gradle-latest-versions.yml
+++ b/.github/workflows/gradle-latest-versions.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   gradle-compatTest:
-    name: "Compatibility tests for latest Gradle versions"
+    name: "Compatibility tests with latest Gradle versions"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -23,7 +23,7 @@ jobs:
         run: |
           echo -n "" > .stutter/java11.lock
           for gv in current release-candidate nightly release-nightly; do
-            echo "Fetching and setting Gradle version for $gv"
+            echo "Fetching and setting Gradle version for '$gv'"
             wget -O- -q https://services.gradle.org/versions/$gv | jq -r '.version | select( . != null )' >> .stutter/java11.lock
           done
           echo "Configured Gradle versions for compatibility tests:"

--- a/.github/workflows/gradle-latest-versions.yml
+++ b/.github/workflows/gradle-latest-versions.yml
@@ -3,9 +3,6 @@ name: Gradle latest versions tests
 on:
   schedule:
     - cron: "0 7 * * MON"
-  push:
-    branches:
-      - "szpak/gradleLatestVersionsGHActions"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/gradle-latest-versions.yml
+++ b/.github/workflows/gradle-latest-versions.yml
@@ -6,8 +6,8 @@ on:
     - cron: "0 7 * * MON"
   push:
     branches:
-      - "gradleLatestVersionsTestManualTrigger"
       - "szpak/gradleLatestVersionsGHActions"
+  workflow_dispatch:
 
 jobs:
   gradle-compatTest:

--- a/.github/workflows/gradle-latest-versions.yml
+++ b/.github/workflows/gradle-latest-versions.yml
@@ -1,4 +1,3 @@
-# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 name: Gradle latest versions tests
 
 on:

--- a/.github/workflows/gradle-latest-versions.yml
+++ b/.github/workflows/gradle-latest-versions.yml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Gradle latest versions tests
+
+on:
+  schedule:
+    - cron: "0 7 * * MON"
+  push:
+    branches:
+      - "gradleLatestVersionsTestManualTrigger"
+      - "szpak/gradleLatestVersionsGHActions"
+
+jobs:
+  gradle-compatTest:
+    name: "Compatibility tests for latest Gradle versions"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          java-version: 11
+          distribution: 'zulu'
+      - name: Fetch and set latest Gradle versions to test with
+        run: |
+          echo -n "" > .stutter/java11.lock
+          for gv in current release-candidate nightly release-nightly; do
+            echo "Fetching and setting Gradle version for $gv"
+            wget -O- -q https://services.gradle.org/versions/$gv | jq -r '.version | select( . != null )' >> .stutter/java11.lock
+          done
+          echo "Configured Gradle versions for compatibility tests:"
+          cat .stutter/java11.lock
+      - name: Run compatTest
+        run: ./gradlew --continue test compatTest

--- a/.github/workflows/gradle-latest-versions.yml
+++ b/.github/workflows/gradle-latest-versions.yml
@@ -26,7 +26,7 @@ jobs:
             echo "Fetching and setting Gradle version for '$gv'"
             wget -O- -q https://services.gradle.org/versions/$gv | jq -r '.version | select( . != null )' >> .stutter/java11.lock
           done
-          echo "Configured Gradle versions for compatibility tests:"
+          echo "Gradle versions configured for compatibility tests:"
           cat .stutter/java11.lock
       - name: Run compatTest
         run: ./gradlew --continue test compatTest

--- a/.github/workflows/gradle-latest-versions.yml
+++ b/.github/workflows/gradle-latest-versions.yml
@@ -19,14 +19,27 @@ jobs:
         with:
           java-version: 11
           distribution: 'zulu'
-      - name: Fetch and set latest Gradle versions to test with
+
+      - name: Fetch latest available Gradle versions
         run: |
-          echo -n "" > .stutter/java11.lock
-          for gv in current release-candidate nightly release-nightly; do
-            echo "Fetching and setting Gradle version for '$gv'"
-            wget -O- -q https://services.gradle.org/versions/$gv | jq -r '.version | select( . != null )' >> .stutter/java11.lock
+          GRADLE_VERSIONS_TYPES_TO_FETCH="current release-candidate nightly release-nightly"
+          GRADLE_VERSIONS_OUTPUT_FILE=latest-gradle-versions.txt
+
+          for gv in $GRADLE_VERSIONS_TYPES_TO_FETCH; do
+            echo "Fetching latest Gradle version for '$gv'"
+            curl --silent --show-error "https://services.gradle.org/versions/$gv" | jq -r '.version | select( . != null )' >> latest-gradle-versions.txt
           done
+
+          echo -e "\nGradle versions configured for compatibility tests (in $GRADLE_VERSIONS_OUTPUT_FILE):"
+          cat $GRADLE_VERSIONS_OUTPUT_FILE
+
+          echo "GRADLE_VERSIONS_OUTPUT_FILE=$GRADLE_VERSIONS_OUTPUT_FILE" >> $GITHUB_ENV
+
+      - name: Set latest Gradle versions to test with
+        run: |
+          cp "${{ env.GRADLE_VERSIONS_OUTPUT_FILE }}" .stutter/java11.lock
           echo "Gradle versions configured for compatibility tests:"
           cat .stutter/java11.lock
+
       - name: Run compatTest
         run: ./gradlew --continue test compatTest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     branches:
       - '*'
+  merge_group:
 
 jobs:
   gradle:


### PR DESCRIPTION
To faster detect regressions, deprecations and incompatibilities. Simple variant to get started.

Closes #173.