### PR TITLE
Test basic Java 17 compatibility on CI

### DIFF
--- a/.github/workflows/java-versions.yml
+++ b/.github/workflows/java-versions.yml
@@ -15,7 +15,7 @@ jobs:
   openjdk:
     strategy:
       matrix:
-        jdk: [8, 11, 15]
+        jdk: [8, 11, 17]
     name: "OpenJDK ${{ matrix.jdk }}"
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
With Gradle 8.0 instead of 6.x, it is possible.
