### PR TITLE
[#181] Limit E2E test execution

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,8 +6,8 @@ on:
   push:
     branches:
       - master
-      - "szpak/**"
-      - "marc/**"
+      - "e2e/**"
+  workflow_dispatch:
 
 jobs:
   tests:


### PR DESCRIPTION
To do not overuse Sonatype Nexus.

A simple version (without parsing the commit message). A manual execution could be used to trigger E2E tests also for other branches. WDYT?

Closes #181.