### PR TITLE
Exclude bogus dependency found by Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,11 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
+  ],
+  "packageRules": [
+    {
+      "matchPackagePrefixes": ["publishing:maven"],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
To prevent:
Renovate failed to look up the following dependencies: publishing:maven.