### PR TITLE
Update com.gradle.plugin-publish to 1.2.0 and remove workaround

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     `kotlin-dsl`
-    id("com.gradle.plugin-publish") version "1.1.0"
+    id("com.gradle.plugin-publish") version "1.2.0"
     // From 6.14.0 onwards Spotless requires Gradle to be on Java 11,
     // but we still use Java 8 in .github/workflows/java-versions.yml.
     id("com.diffplug.spotless") version "6.13.0"
@@ -78,8 +78,6 @@ configurations {
     testImplementation {
         exclude(group = "junit", module = "junit")
     }
-    // Workaround https://github.com/gradle/gradle/issues/23928
-    shadow.configure { afterEvaluate { this@configure.dependencies.remove(project.dependencies.gradleApi()) } }
 }
 
 dependencies {


### PR DESCRIPTION
Remove workaround for https://github.com/gradle/gradle/issues/23928

https://plugins.gradle.org/plugin/com.gradle.plugin-publish has a new version 1.2.0

cc @vlsi 