### PR TITLE
Fix most of configuration cache warnings

### DIFF
--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/AbstractNexusStagingRepositoryTask.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/AbstractNexusStagingRepositoryTask.kt
@@ -50,7 +50,6 @@ constructor(objects: ObjectFactory, extension: NexusPublishExtension, repository
         set(extension.repositoryDescription)
     }
 
-    @Internal
     private val useStaging = objects.property<Boolean>().apply {
         set(extension.useStaging)
     }

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/AbstractNexusStagingRepositoryTask.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/AbstractNexusStagingRepositoryTask.kt
@@ -50,7 +50,12 @@ constructor(objects: ObjectFactory, extension: NexusPublishExtension, repository
         set(extension.repositoryDescription)
     }
 
+    @Internal
+    private val useStaging = objects.property<Boolean>().apply {
+        set(extension.useStaging)
+    }
+
     init {
-        this.onlyIf { extension.useStaging.getOrElse(false) }
+        this.onlyIf { useStaging.getOrElse(false) }
     }
 }


### PR DESCRIPTION
Contributes to https://github.com/gradle-nexus/publish-plugin/issues/221, but doesn't not fully fix it.

All problems were rooted in this one common place, a captured `extension` object.

<details><summary>Evidence that all warnings are involved</summary>

From configuration-cache report posted here: https://github.com/gradle-nexus/publish-plugin/issues/221#issuecomment-1550964355

![FireShot Capture 001 - Gradle Configuration Cache - ](https://github.com/gradle-nexus/publish-plugin/assets/2906988/7fce9ea7-57ec-46fa-a084-72b92720cca1)

</details>