### PR TITLE
[#171] Remove JDK 8 build on CI

### DIFF
--- a/.github/workflows/java-versions.yml
+++ b/.github/workflows/java-versions.yml
@@ -15,7 +15,7 @@ jobs:
   openjdk:
     strategy:
       matrix:
-        jdk: [8, 11, 17]
+        jdk: [11, 17]
     name: "OpenJDK ${{ matrix.jdk }}"
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Build with JDK 8 will not be officially supported in 2.0.0. Although, it is still planned to have target set to JDK 8.

It also slightly speed up CI build (or at least decrease the load we generate).