### PR TITLE
Enable Gradle build scan for tests with latest Gradle version

### DIFF
--- a/.github/workflows/gradle-latest-versions.yml
+++ b/.github/workflows/gradle-latest-versions.yml
@@ -38,4 +38,4 @@ jobs:
           cat stutter.lockfile
 
       - name: Run compatTest
-        run: ./gradlew --continue test compatTest
+        run: ./gradlew --scan --continue test compatTest


### PR DESCRIPTION
To make it easier to find our why the regression tests fail.