### PR TITLE
Partially refactor to use more idiomatic Gradle

### DIFF
--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/AbstractNexusStagingRepositoryTask.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/AbstractNexusStagingRepositoryTask.kt
@@ -26,17 +26,13 @@ import java.time.Duration
 import javax.inject.Inject
 
 abstract class AbstractNexusStagingRepositoryTask @Inject
-constructor(objects: ObjectFactory, extension: NexusPublishExtension, repository: NexusRepository) : DefaultTask() {
+constructor(objects: ObjectFactory, repository: NexusRepository) : DefaultTask() {
 
     @Internal
-    val clientTimeout = objects.property<Duration>().apply {
-        set(extension.clientTimeout)
-    }
+    val clientTimeout = objects.property<Duration>()
 
     @Internal
-    val connectTimeout = objects.property<Duration>().apply {
-        set(extension.connectTimeout)
-    }
+    val connectTimeout = objects.property<Duration>()
 
     // TODO: Expose externally as interface with getters only
     @Nested
@@ -45,13 +41,10 @@ constructor(objects: ObjectFactory, extension: NexusPublishExtension, repository
     }
 
     @Input
-    val repositoryDescription = objects.property<String>().apply {
-        set(extension.repositoryDescription)
-    }
+    val repositoryDescription = objects.property<String>()
 
-    private val useStaging = objects.property<Boolean>().apply {
-        set(extension.useStaging)
-    }
+    @get:Internal
+    internal val useStaging = objects.property<Boolean>()
 
     init {
         this.onlyIf { useStaging.getOrElse(false) }

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/AbstractNexusStagingRepositoryTask.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/AbstractNexusStagingRepositoryTask.kt
@@ -18,6 +18,7 @@ package io.github.gradlenexus.publishplugin
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Nested
@@ -28,11 +29,11 @@ import javax.inject.Inject
 abstract class AbstractNexusStagingRepositoryTask @Inject
 constructor(objects: ObjectFactory, repository: NexusRepository) : DefaultTask() {
 
-    @Internal
-    val clientTimeout = objects.property<Duration>()
+    @get:Internal
+    abstract val clientTimeout: Property<Duration>
 
-    @Internal
-    val connectTimeout = objects.property<Duration>()
+    @get:Internal
+    abstract val connectTimeout: Property<Duration>
 
     // TODO: Expose externally as interface with getters only
     @Nested
@@ -40,11 +41,11 @@ constructor(objects: ObjectFactory, repository: NexusRepository) : DefaultTask()
         set(repository)
     }
 
-    @Input
-    val repositoryDescription = objects.property<String>()
+    @get:Input
+    abstract val repositoryDescription: Property<String>
 
     @get:Internal
-    internal val useStaging = objects.property<Boolean>()
+    internal abstract val useStaging: Property<Boolean>
 
     init {
         this.onlyIf { useStaging.getOrElse(false) }

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/AbstractTransitionNexusStagingRepositoryTask.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/AbstractTransitionNexusStagingRepositoryTask.kt
@@ -34,7 +34,7 @@ abstract class AbstractTransitionNexusStagingRepositoryTask(
     extension: NexusPublishExtension,
     repository: NexusRepository,
     registry: Provider<InvalidatingStagingRepositoryDescriptorRegistry>
-) : AbstractNexusStagingRepositoryTask(objects, extension, repository) {
+) : AbstractNexusStagingRepositoryTask(objects, repository) {
 
     @Input
     val stagingRepositoryId = objects.property<String>().apply {

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/AbstractTransitionNexusStagingRepositoryTask.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/AbstractTransitionNexusStagingRepositoryTask.kt
@@ -23,6 +23,7 @@ import io.github.gradlenexus.publishplugin.internal.StagingRepository
 import io.github.gradlenexus.publishplugin.internal.StagingRepositoryTransitioner
 import org.gradle.api.Action
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
@@ -44,8 +45,8 @@ abstract class AbstractTransitionNexusStagingRepositoryTask(
         )
     }
 
-    @Internal
-    val transitionCheckOptions = project.objects.property<TransitionCheckOptions>()
+    @get:Internal
+    abstract val transitionCheckOptions: Property<TransitionCheckOptions>
 
     fun transitionCheckOptions(action: Action<in TransitionCheckOptions>) = action.execute(transitionCheckOptions.get())
 

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/AbstractTransitionNexusStagingRepositoryTask.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/AbstractTransitionNexusStagingRepositoryTask.kt
@@ -31,7 +31,6 @@ import org.gradle.kotlin.dsl.property
 
 abstract class AbstractTransitionNexusStagingRepositoryTask(
     objects: ObjectFactory,
-    extension: NexusPublishExtension,
     repository: NexusRepository,
     registry: Provider<InvalidatingStagingRepositoryDescriptorRegistry>
 ) : AbstractNexusStagingRepositoryTask(objects, repository) {
@@ -46,9 +45,7 @@ abstract class AbstractTransitionNexusStagingRepositoryTask(
     }
 
     @Internal
-    val transitionCheckOptions = project.objects.property<TransitionCheckOptions>().apply {
-        set(extension.transitionCheckOptions)
-    }
+    val transitionCheckOptions = project.objects.property<TransitionCheckOptions>()
 
     fun transitionCheckOptions(action: Action<in TransitionCheckOptions>) = action.execute(transitionCheckOptions.get())
 

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/CloseNexusStagingRepository.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/CloseNexusStagingRepository.kt
@@ -23,7 +23,7 @@ import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.options.Option
 import javax.inject.Inject
 
-open class CloseNexusStagingRepository @Inject constructor(
+abstract class CloseNexusStagingRepository @Inject constructor(
     objects: ObjectFactory,
     repository: NexusRepository,
     registry: Provider<InvalidatingStagingRepositoryDescriptorRegistry>

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/CloseNexusStagingRepository.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/CloseNexusStagingRepository.kt
@@ -25,10 +25,9 @@ import javax.inject.Inject
 
 open class CloseNexusStagingRepository @Inject constructor(
     objects: ObjectFactory,
-    extension: NexusPublishExtension,
     repository: NexusRepository,
     registry: Provider<InvalidatingStagingRepositoryDescriptorRegistry>
-) : AbstractTransitionNexusStagingRepositoryTask(objects, extension, repository, registry) {
+) : AbstractTransitionNexusStagingRepositoryTask(objects, repository, registry) {
 
     @Option(option = "staging-repository-id", description = "staging repository id to close")
     fun setStagingRepositoryId(stagingRepositoryId: String) {

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/FindStagingRepository.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/FindStagingRepository.kt
@@ -35,7 +35,7 @@ open class FindStagingRepository @Inject constructor(
     extension: NexusPublishExtension,
     repository: NexusRepository,
     private val registry: Provider<InvalidatingStagingRepositoryDescriptorRegistry>
-) : AbstractNexusStagingRepositoryTask(objects, extension, repository) {
+) : AbstractNexusStagingRepositoryTask(objects, repository) {
 
     @Optional
     @Input

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/FindStagingRepository.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/FindStagingRepository.kt
@@ -30,7 +30,7 @@ import org.gradle.kotlin.dsl.property
 import javax.inject.Inject
 
 @Incubating
-open class FindStagingRepository @Inject constructor(
+abstract class FindStagingRepository @Inject constructor(
     objects: ObjectFactory,
     extension: NexusPublishExtension,
     repository: NexusRepository,

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/InitializeNexusStagingRepository.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/InitializeNexusStagingRepository.kt
@@ -33,7 +33,7 @@ open class InitializeNexusStagingRepository @Inject constructor(
     extension: NexusPublishExtension,
     repository: NexusRepository,
     private val registry: Provider<InvalidatingStagingRepositoryDescriptorRegistry>
-) : AbstractNexusStagingRepositoryTask(objects, extension, repository) {
+) : AbstractNexusStagingRepositoryTask(objects, repository) {
 
     @Optional
     @Input

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/InitializeNexusStagingRepository.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/InitializeNexusStagingRepository.kt
@@ -28,7 +28,7 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.kotlin.dsl.property
 import javax.inject.Inject
 
-open class InitializeNexusStagingRepository @Inject constructor(
+abstract class InitializeNexusStagingRepository @Inject constructor(
     objects: ObjectFactory,
     extension: NexusPublishExtension,
     repository: NexusRepository,

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishExtension.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishExtension.kt
@@ -19,31 +19,33 @@ package io.github.gradlenexus.publishplugin
 import org.gradle.api.Action
 import org.gradle.api.NamedDomainObjectFactory
 import org.gradle.api.Project
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Nested
 import org.gradle.kotlin.dsl.container
 import org.gradle.kotlin.dsl.newInstance
-import org.gradle.kotlin.dsl.property
 import java.time.Duration
 
-open class NexusPublishExtension(project: Project) {
+abstract class NexusPublishExtension(project: Project) {
 
     companion object {
         internal const val NAME = "nexusPublishing"
     }
 
-    val useStaging = project.objects.property<Boolean>()
+    abstract val useStaging: Property<Boolean>
 
-    val packageGroup = project.objects.property<String>()
+    abstract val packageGroup: Property<String>
 
-    val repositoryDescription = project.objects.property<String>()
+    abstract val repositoryDescription: Property<String>
 
     // staging repository initialization can take a few minutes on Sonatype Nexus
-    val clientTimeout = project.objects.property<Duration>()
+    abstract val clientTimeout: Property<Duration>
 
-    val connectTimeout = project.objects.property<Duration>()
+    abstract val connectTimeout: Property<Duration>
 
-    val transitionCheckOptions = project.objects.property<TransitionCheckOptions>()
+    @get:Nested
+    abstract val transitionCheckOptions: TransitionCheckOptions
 
-    fun transitionCheckOptions(action: Action<in TransitionCheckOptions>) = action.execute(transitionCheckOptions.get())
+    fun transitionCheckOptions(action: Action<in TransitionCheckOptions>) = action.execute(transitionCheckOptions)
 
     val repositories: NexusRepositoryContainer = project.objects.newInstance(
         DefaultNexusRepositoryContainer::class,

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishExtension.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishExtension.kt
@@ -30,24 +30,18 @@ open class NexusPublishExtension(project: Project) {
         internal const val NAME = "nexusPublishing"
     }
 
-    val useStaging = project.objects.property<Boolean>().apply {
-        set(project.provider { !project.version.toString().endsWith("-SNAPSHOT") })
-    }
+    val useStaging = project.objects.property<Boolean>()
 
-    val packageGroup = project.objects.property<String>().apply {
-        set(project.provider { project.group.toString() })
-    }
+    val packageGroup = project.objects.property<String>()
 
-    val repositoryDescription = project.objects.property<String>().apply {
-        set(project.provider { project.run { "$group:$name:$version" } })
-    }
+    val repositoryDescription = project.objects.property<String>()
 
     // staging repository initialization can take a few minutes on Sonatype Nexus
-    val clientTimeout = project.objects.property<Duration>().value(Duration.ofMinutes(5))
+    val clientTimeout = project.objects.property<Duration>()
 
-    val connectTimeout = project.objects.property<Duration>().value(Duration.ofMinutes(5))
+    val connectTimeout = project.objects.property<Duration>()
 
-    val transitionCheckOptions = project.objects.property<TransitionCheckOptions>().value(project.objects.newInstance(TransitionCheckOptions::class))
+    val transitionCheckOptions = project.objects.property<TransitionCheckOptions>()
 
     fun transitionCheckOptions(action: Action<in TransitionCheckOptions>) = action.execute(transitionCheckOptions.get())
 

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishExtension.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishExtension.kt
@@ -18,14 +18,15 @@ package io.github.gradlenexus.publishplugin
 
 import org.gradle.api.Action
 import org.gradle.api.NamedDomainObjectFactory
-import org.gradle.api.Project
+import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Nested
-import org.gradle.kotlin.dsl.container
+import org.gradle.kotlin.dsl.domainObjectContainer
 import org.gradle.kotlin.dsl.newInstance
 import java.time.Duration
+import javax.inject.Inject
 
-abstract class NexusPublishExtension(project: Project) {
+abstract class NexusPublishExtension @Inject constructor(objects: ObjectFactory) {
 
     companion object {
         internal const val NAME = "nexusPublishing"
@@ -47,15 +48,15 @@ abstract class NexusPublishExtension(project: Project) {
 
     fun transitionCheckOptions(action: Action<in TransitionCheckOptions>) = action.execute(transitionCheckOptions)
 
-    val repositories: NexusRepositoryContainer = project.objects.newInstance(
+    val repositories: NexusRepositoryContainer = objects.newInstance(
         DefaultNexusRepositoryContainer::class,
-        // `project.container(NexusRepository::class) { name -> ... }`,
+        // `objects.domainObjectContainer(NexusRepository::class) { name -> ... }`,
         // but in Kotlin 1.3 "New Inference" is not implemented yet, so we have to be explicit.
         // https://kotlinlang.org/docs/whatsnew14.html#new-more-powerful-type-inference-algorithm
-        project.container(
+        objects.domainObjectContainer(
             NexusRepository::class,
             NamedDomainObjectFactory { name ->
-                project.objects.newInstance(NexusRepository::class, name)
+                objects.newInstance(NexusRepository::class, name)
             }
         )
     )

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishExtension.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishExtension.kt
@@ -59,7 +59,7 @@ open class NexusPublishExtension(project: Project) {
         project.container(
             NexusRepository::class,
             NamedDomainObjectFactory { name ->
-                project.objects.newInstance(NexusRepository::class, name, project)
+                project.objects.newInstance(NexusRepository::class, name)
             }
         )
     )

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishPlugin.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishPlugin.kt
@@ -82,13 +82,13 @@ class NexusPublishPlugin : Plugin<Project> {
     }
 
     private fun configureNexusTasks(rootProject: Project, extension: NexusPublishExtension, registry: Provider<InvalidatingStagingRepositoryDescriptorRegistry>) {
-        rootProject.tasks.withType(AbstractNexusStagingRepositoryTask::class.java) {
+        rootProject.tasks.withType(AbstractNexusStagingRepositoryTask::class.java).configureEach {
             clientTimeout.convention(extension.clientTimeout)
             connectTimeout.convention(extension.connectTimeout)
             repositoryDescription.convention(extension.repositoryDescription)
             useStaging.convention(extension.useStaging)
         }
-        rootProject.tasks.withType(AbstractTransitionNexusStagingRepositoryTask::class.java) {
+        rootProject.tasks.withType(AbstractTransitionNexusStagingRepositoryTask::class.java).configureEach {
             transitionCheckOptions.convention(extension.transitionCheckOptions)
         }
         extension.repositories.all {

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishPlugin.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishPlugin.kt
@@ -88,6 +88,9 @@ class NexusPublishPlugin : Plugin<Project> {
             repositoryDescription.convention(extension.repositoryDescription)
             useStaging.convention(extension.useStaging)
         }
+        rootProject.tasks.withType(AbstractTransitionNexusStagingRepositoryTask::class.java) {
+            transitionCheckOptions.convention(extension.transitionCheckOptions)
+        }
         extension.repositories.all {
             username.convention(rootProject.provider { rootProject.findProperty("${name}Username") as? String })
             password.convention(rootProject.provider { rootProject.findProperty("${name}Password") as? String })
@@ -115,14 +118,12 @@ class NexusPublishPlugin : Plugin<Project> {
             val closeTask = rootProject.tasks.register<CloseNexusStagingRepository>(
                 "close${capitalizedName}StagingRepository",
                 rootProject.objects,
-                extension,
                 repository,
                 registry
             )
             val releaseTask = rootProject.tasks.register<ReleaseNexusStagingRepository>(
                 "release${capitalizedName}StagingRepository",
                 rootProject.objects,
-                extension,
                 repository,
                 registry
             )

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishPlugin.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishPlugin.kt
@@ -69,6 +69,10 @@ class NexusPublishPlugin : Plugin<Project> {
 
     private fun configureNexusTasks(rootProject: Project, extension: NexusPublishExtension, registry: Provider<InvalidatingStagingRepositoryDescriptorRegistry>) {
         extension.repositories.all {
+            username.convention(rootProject.provider { rootProject.findProperty("${name}Username") as? String })
+            password.convention(rootProject.provider { rootProject.findProperty("${name}Password") as? String })
+            publicationType.convention(PublicationType.MAVEN)
+
             val repository = this
             val retrieveStagingProfileTask = rootProject.tasks.register<RetrieveStagingProfile>("retrieve${capitalizedName}StagingProfile", rootProject.objects, extension, repository)
             val initializeTask = rootProject.tasks.register<InitializeNexusStagingRepository>(

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishPlugin.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishPlugin.kt
@@ -55,7 +55,7 @@ class NexusPublishPlugin : Plugin<Project> {
         }
 
         val registry = createRegistry(project)
-        val extension = project.extensions.create<NexusPublishExtension>(NexusPublishExtension.NAME, project)
+        val extension = project.extensions.create<NexusPublishExtension>(NexusPublishExtension.NAME)
         configureExtension(project, extension)
         configureNexusTasks(project, extension, registry)
         configurePublishingForAllProjects(project, extension, registry)

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishPlugin.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishPlugin.kt
@@ -82,6 +82,12 @@ class NexusPublishPlugin : Plugin<Project> {
     }
 
     private fun configureNexusTasks(rootProject: Project, extension: NexusPublishExtension, registry: Provider<InvalidatingStagingRepositoryDescriptorRegistry>) {
+        rootProject.tasks.withType(AbstractNexusStagingRepositoryTask::class.java) {
+            clientTimeout.convention(extension.clientTimeout)
+            connectTimeout.convention(extension.connectTimeout)
+            repositoryDescription.convention(extension.repositoryDescription)
+            useStaging.convention(extension.useStaging)
+        }
         extension.repositories.all {
             username.convention(rootProject.provider { rootProject.findProperty("${name}Username") as? String })
             password.convention(rootProject.provider { rootProject.findProperty("${name}Password") as? String })

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishPlugin.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishPlugin.kt
@@ -68,6 +68,8 @@ class NexusPublishPlugin : Plugin<Project> {
             repositoryDescription.convention(project.provider { project.run { "$group:$name:$version" } })
             clientTimeout.convention(Duration.ofMinutes(5))
             connectTimeout.convention(Duration.ofMinutes(5))
+            transitionCheckOptions.maxRetries.convention(60)
+            transitionCheckOptions.delayBetween.convention(Duration.ofSeconds(10))
         }
     }
 

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusRepository.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusRepository.kt
@@ -43,17 +43,13 @@ open class NexusRepository @Inject constructor(@Input val name: String, project:
     val snapshotRepositoryUrl = project.objects.property<URI>()
 
     @Input
-    val publicationType: Property<PublicationType> = project.objects.property<PublicationType>().convention(PublicationType.MAVEN)
+    val publicationType: Property<PublicationType> = project.objects.property<PublicationType>()
 
     @Internal
-    val username = project.objects.property<String>().apply {
-        set(project.provider { project.findProperty("${name}Username") as? String })
-    }
+    val username = project.objects.property<String>()
 
     @Internal
-    val password = project.objects.property<String>().apply {
-        set(project.provider { project.findProperty("${name}Password") as? String })
-    }
+    val password = project.objects.property<String>()
 
     @Internal
     val allowInsecureProtocol = project.objects.property<Boolean>()

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusRepository.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusRepository.kt
@@ -18,7 +18,6 @@ package io.github.gradlenexus.publishplugin
 
 import org.gradle.api.Action
 import org.gradle.api.DefaultTask
-import org.gradle.api.Project
 import org.gradle.api.artifacts.repositories.IvyPatternRepositoryLayout
 import org.gradle.api.provider.Property
 import org.gradle.api.publish.Publication
@@ -29,41 +28,40 @@ import org.gradle.api.publish.maven.tasks.PublishToMavenRepository
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
-import org.gradle.kotlin.dsl.property
 import java.net.URI
 import javax.inject.Inject
 import kotlin.reflect.KClass
 
-open class NexusRepository @Inject constructor(@Input val name: String, project: Project) {
+abstract class NexusRepository @Inject constructor(@Input val name: String) {
 
-    @Input
-    val nexusUrl = project.objects.property<URI>()
+    @get:Input
+    abstract val nexusUrl: Property<URI>
 
-    @Input
-    val snapshotRepositoryUrl = project.objects.property<URI>()
+    @get:Input
+    abstract val snapshotRepositoryUrl: Property<URI>
 
-    @Input
-    val publicationType: Property<PublicationType> = project.objects.property<PublicationType>()
+    @get:Input
+    abstract val publicationType: Property<PublicationType>
 
-    @Internal
-    val username = project.objects.property<String>()
+    @get:Internal
+    abstract val username: Property<String>
 
-    @Internal
-    val password = project.objects.property<String>()
+    @get:Internal
+    abstract val password: Property<String>
 
-    @Internal
-    val allowInsecureProtocol = project.objects.property<Boolean>()
+    @get:Internal
+    abstract val allowInsecureProtocol: Property<Boolean>
 
-    @Optional
-    @Input
-    val stagingProfileId = project.objects.property<String>()
+    @get:Optional
+    @get:Input
+    abstract val stagingProfileId: Property<String>
 
     @get:Internal
     internal val capitalizedName by lazy { name.capitalize() }
 
-    @Optional
-    @Input
-    val ivyPatternLayout: Property<Action<IvyPatternRepositoryLayout>> = project.objects.property<Action<IvyPatternRepositoryLayout>>()
+    @get:Optional
+    @get:Input
+    abstract val ivyPatternLayout: Property<Action<IvyPatternRepositoryLayout>>
     fun ivyPatternLayout(action: Action<IvyPatternRepositoryLayout>) {
         ivyPatternLayout.set(action)
     }

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/ReleaseNexusStagingRepository.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/ReleaseNexusStagingRepository.kt
@@ -25,10 +25,9 @@ import javax.inject.Inject
 
 open class ReleaseNexusStagingRepository @Inject constructor(
     objects: ObjectFactory,
-    extension: NexusPublishExtension,
     repository: NexusRepository,
     registry: Provider<InvalidatingStagingRepositoryDescriptorRegistry>
-) : AbstractTransitionNexusStagingRepositoryTask(objects, extension, repository, registry) {
+) : AbstractTransitionNexusStagingRepositoryTask(objects, repository, registry) {
 
     @Option(option = "staging-repository-id", description = "staging repository id to release")
     fun setStagingRepositoryId(stagingRepositoryId: String) {

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/ReleaseNexusStagingRepository.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/ReleaseNexusStagingRepository.kt
@@ -23,7 +23,7 @@ import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.options.Option
 import javax.inject.Inject
 
-open class ReleaseNexusStagingRepository @Inject constructor(
+abstract class ReleaseNexusStagingRepository @Inject constructor(
     objects: ObjectFactory,
     repository: NexusRepository,
     registry: Provider<InvalidatingStagingRepositoryDescriptorRegistry>

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/RetrieveStagingProfile.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/RetrieveStagingProfile.kt
@@ -33,7 +33,7 @@ open class RetrieveStagingProfile @Inject constructor(
     objects: ObjectFactory,
     extension: NexusPublishExtension,
     repository: NexusRepository
-) : AbstractNexusStagingRepositoryTask(objects, extension, repository) {
+) : AbstractNexusStagingRepositoryTask(objects, repository) {
 
     @Input
     val packageGroup = objects.property<String>().apply {

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/RetrieveStagingProfile.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/RetrieveStagingProfile.kt
@@ -29,7 +29,7 @@ import javax.inject.Inject
  * Diagnostic task for retrieving the [NexusRepository.stagingProfileId] for the [packageGroup] from the provided [NexusRepository] and logging it
  */
 @Incubating
-open class RetrieveStagingProfile @Inject constructor(
+abstract class RetrieveStagingProfile @Inject constructor(
     objects: ObjectFactory,
     extension: NexusPublishExtension,
     repository: NexusRepository

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/TransitionCheckOptions.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/TransitionCheckOptions.kt
@@ -23,7 +23,7 @@ import javax.inject.Inject
 
 open class TransitionCheckOptions @Inject constructor(objects: ObjectFactory) {
 
-    val maxRetries = objects.property<Int>().value(60)
+    val maxRetries = objects.property<Int>()
 
-    val delayBetween = objects.property<Duration>().value(Duration.ofSeconds(10))
+    val delayBetween = objects.property<Duration>()
 }

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/TransitionCheckOptions.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/TransitionCheckOptions.kt
@@ -16,14 +16,12 @@
 
 package io.github.gradlenexus.publishplugin
 
-import org.gradle.api.model.ObjectFactory
-import org.gradle.kotlin.dsl.property
+import org.gradle.api.provider.Property
 import java.time.Duration
-import javax.inject.Inject
 
-open class TransitionCheckOptions @Inject constructor(objects: ObjectFactory) {
+interface TransitionCheckOptions {
 
-    val maxRetries = objects.property<Int>()
+    val maxRetries: Property<Int>
 
-    val delayBetween = objects.property<Duration>()
+    val delayBetween: Property<Duration>
 }

--- a/src/test/kotlin/io/github/gradlenexus/publishplugin/TaskOrchestrationTest.kt
+++ b/src/test/kotlin/io/github/gradlenexus/publishplugin/TaskOrchestrationTest.kt
@@ -67,7 +67,7 @@ class TaskOrchestrationTest {
         // given
         initSingleProjectWithDefaultConfiguration()
         project.extensions.configure<NexusPublishExtension> {
-            repositories.add(NexusRepository("myNexus", project))
+            repositories.create("myNexus")
         }
         // expect
         assertGivenTaskMustNotRunAfterAnother(transitioningTaskName, "publishToMyNexus")


### PR DESCRIPTION
The main changes are:
1. Use managed properties, where possible
2. Avoid passing instances of `Project` around
3. Use the plugin to set default values in tasks and the extension

Parts 1 & 3 are not fully completed but I didn't want to press on if this wasn't desired. This should be safe to merge as is though as compat tests for Gradle 6 on Java 11 pass locally.