### PR TITLE
Fix #228: reduce parallelism in task and increase parallelism between tasks

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -162,42 +162,38 @@ sourceSets {
     }
 }
 
-kotlin {
-    target {
-        compilations.configureEach {
-            // Supporting Gradle 6.0+ needs to use Kotlin 1.3.
-            // See https://docs.gradle.org/current/userguide/compatibility.html
-            // For future maintainer: Kotlin 1.9.0 dropped support for Kotlin 1.3, it'll only support 1.4+.
-            // This means Gradle 7.0 will be the lowest supportable version for plugins.
-            val usedKotlinVersion = @Suppress("DEPRECATION") KotlinVersion.KOTLIN_1_3
+kotlin.target.compilations.configureEach {
+    // Supporting Gradle 6.0+ needs to use Kotlin 1.3.
+    // See https://docs.gradle.org/current/userguide/compatibility.html
+    // For future maintainer: Kotlin 1.9.0 dropped support for Kotlin 1.3, it'll only support 1.4+.
+    // This means Gradle 7.0 will be the lowest supportable version for plugins.
+    val usedKotlinVersion = @Suppress("DEPRECATION") KotlinVersion.KOTLIN_1_3
 
-            compilerOptions.configure {
-                // Gradle fully supports running on Java 8: https://docs.gradle.org/current/userguide/compatibility.html,
-                // so we should allow users to do that too.
-                jvmTarget = JvmTarget.fromTarget(JavaVersion.VERSION_1_8.toString())
+    compilerOptions.configure {
+        // Gradle fully supports running on Java 8: https://docs.gradle.org/current/userguide/compatibility.html,
+        // so we should allow users to do that too.
+        jvmTarget = JvmTarget.fromTarget(JavaVersion.VERSION_1_8.toString())
 
-                // Suppress "Language version 1.3 is deprecated and its support will be removed in a future version of Kotlin".
-                freeCompilerArgs.add("-Xsuppress-version-warnings")
-            }
-            compileTaskProvider.configure {
-                // These two (api & lang) needs to be here instead of in compilations.compilerOptions.configure { },
-                // to prevent KotlinDslCompilerPlugins overriding to Kotlin 1.8.
-                compilerOptions.apiVersion = usedKotlinVersion
-                // Theoretically we could use newer language version here,
-                // but sadly the @kotlin.Metadata created on the classes would be incompatible with older consumers.
-                compilerOptions.languageVersion = usedKotlinVersion
+        // Suppress "Language version 1.3 is deprecated and its support will be removed in a future version of Kotlin".
+        freeCompilerArgs.add("-Xsuppress-version-warnings")
+    }
+    compileTaskProvider.configure {
+        // These two (api & lang) needs to be here instead of in compilations.compilerOptions.configure { },
+        // to prevent KotlinDslCompilerPlugins overriding to Kotlin 1.8.
+        compilerOptions.apiVersion = usedKotlinVersion
+        // Theoretically we could use newer language version here,
+        // but sadly the @kotlin.Metadata created on the classes would be incompatible with older consumers.
+        compilerOptions.languageVersion = usedKotlinVersion
 
-                // Validate that we're using the right version.
-                doFirst {
-                    val api = compilerOptions.apiVersion.get()
-                    val language = compilerOptions.languageVersion.get()
-                    if (api != usedKotlinVersion || language != usedKotlinVersion) {
-                        TODO(
-                            "There's mismatch between configured and actual versions:\n" +
-                                    "apiVersion=${api}, languageVersion=${language}, configured=${usedKotlinVersion}."
-                        )
-                    }
-                }
+        // Validate that we're using the right version.
+        doFirst {
+            val api = compilerOptions.apiVersion.get()
+            val language = compilerOptions.languageVersion.get()
+            if (api != usedKotlinVersion || language != usedKotlinVersion) {
+                TODO(
+                    "There's mismatch between configured and actual versions:\n" +
+                            "apiVersion=${api}, languageVersion=${language}, configured=${usedKotlinVersion}."
+                )
             }
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -228,7 +228,7 @@ tasks {
     withType<Test>().configureEach {
         dependsOn(shadowJar)
         useJUnitPlatform()
-        maxParallelForks = 8
+        maxParallelForks = if (name.startsWith("compatTest")) 1 else 8
     }
     withType<Test>().matching { it.name.startsWith("compatTest") }.configureEach {
         systemProperty("plugin.version", project.version)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -165,20 +165,13 @@ sourceSets {
 kotlin {
     target {
         compilations.configureEach {
-            // For future maintainer: Kotlin 1.9.0 dropped support for Kotlin 1.3, it'll only support 1.4+.
-            // This means Gradle 7.0 will be the lowest supportable version for plugins.
-
             // Supporting Gradle 6.0+ needs to use Kotlin 1.3.
             // See https://docs.gradle.org/current/userguide/compatibility.html
+            // For future maintainer: Kotlin 1.9.0 dropped support for Kotlin 1.3, it'll only support 1.4+.
+            // This means Gradle 7.0 will be the lowest supportable version for plugins.
             val usedKotlinVersion = @Suppress("DEPRECATION") KotlinVersion.KOTLIN_1_3
 
             compilerOptions.configure {
-                apiVersion = usedKotlinVersion
-
-                // Theoretically we could use newer language version here,
-                // but sadly the @kotlin.Metadata created on the classes would be incompatible with older consumers.
-                languageVersion = usedKotlinVersion
-
                 // Gradle fully supports running on Java 8: https://docs.gradle.org/current/userguide/compatibility.html,
                 // so we should allow users to do that too.
                 jvmTarget = JvmTarget.fromTarget(JavaVersion.VERSION_1_8.toString())
@@ -187,10 +180,12 @@ kotlin {
                 freeCompilerArgs.add("-Xsuppress-version-warnings")
             }
             compileTaskProvider.configure {
-                // This needs to be here too to prevent KotlinDslCompilerPlugins overriding to Kotlin 1.8.
-                compilerOptions.languageVersion = usedKotlinVersion
-                // This needs to be here too to prevent KotlinDslCompilerPlugins overriding to Kotlin 1.8.
+                // These two (api & lang) needs to be here instead of in compilations.compilerOptions.configure { },
+                // to prevent KotlinDslCompilerPlugins overriding to Kotlin 1.8.
                 compilerOptions.apiVersion = usedKotlinVersion
+                // Theoretically we could use newer language version here,
+                // but sadly the @kotlin.Metadata created on the classes would be incompatible with older consumers.
+                compilerOptions.languageVersion = usedKotlinVersion
 
                 // Validate that we're using the right version.
                 doFirst {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,9 @@ import org.gradle.initialization.IGradlePropertiesLoader.SYSTEM_PROJECT_PROPERTI
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    `kotlin-dsl`
+    id("org.gradle.java-gradle-plugin")
+    id("org.jetbrains.kotlin.jvm") version "1.8.22"
+    id("org.jetbrains.kotlin.plugin.sam.with.receiver") version "1.8.22"
     id("com.gradle.plugin-publish") version "1.2.0"
     // From 6.14.0 onwards Spotless requires Gradle to be on Java 11,
     // but we still use Java 8 in .github/workflows/java-versions.yml.
@@ -80,10 +82,12 @@ configurations {
 }
 
 dependencies {
+    compileOnly(gradleKotlinDsl())
     implementation("com.squareup.retrofit2:retrofit:2.9.0")
     implementation("com.squareup.retrofit2:converter-gson:2.9.0")
     implementation("net.jodah:failsafe:2.4.4")
 
+    testImplementation(gradleKotlinDsl())
     testImplementation("org.junit.jupiter:junit-jupiter:5.9.3")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testImplementation("com.github.tomakehurst:wiremock:2.27.2")
@@ -159,6 +163,11 @@ sourceSets {
         runtimeClasspath += sourceSets["test"].output
         runtimeClasspath += sourceSets["main"].output
     }
+}
+
+// Transform Action<T> (i.e. (T) -> Unit) to T.() -> Unit so that .configure { ... } has receivers as they do in gradle.kts.
+samWithReceiver {
+    annotation(HasImplicitReceiver::class.qualifiedName!!)
 }
 
 tasks {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,8 +5,9 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
 plugins {
     id("org.gradle.java-gradle-plugin")
-    id("org.jetbrains.kotlin.jvm") version "1.8.22"
-    id("org.jetbrains.kotlin.plugin.sam.with.receiver") version "1.8.22"
+    id("org.gradle.kotlin.embedded-kotlin") version "4.0.14"
+    id("org.jetbrains.kotlin.jvm") version "1.8.20"
+    id("org.jetbrains.kotlin.plugin.sam.with.receiver") version "1.8.20"
     id("com.gradle.plugin-publish") version "1.2.0"
     // From 6.14.0 onwards Spotless requires Gradle to be on Java 11,
     // but we still use Java 8 in .github/workflows/java-versions.yml.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 org.gradle.caching=true
 org.gradle.parallel=true
+org.gradle.configuration-cache=true

--- a/src/compatTest/kotlin/io/github/gradlenexus/publishplugin/TestExtensions.kt
+++ b/src/compatTest/kotlin/io/github/gradlenexus/publishplugin/TestExtensions.kt
@@ -20,13 +20,13 @@ import java.nio.file.Files
 import java.nio.file.Path
 
 fun Path.write(text: String): Path {
-    Files.createDirectories(parent)
-    toFile().writeText(text)
+    Files.createDirectories(this.parent)
+    this.toFile().writeText(text)
     return this
 }
 
 fun Path.append(text: String): Path {
-    Files.createDirectories(parent)
-    toFile().appendText(text)
+    Files.createDirectories(this.parent)
+    this.toFile().appendText(text)
     return this
 }

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishPlugin.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishPlugin.kt
@@ -187,7 +187,6 @@ class NexusPublishPlugin : Plugin<Project> {
                         val id = when (publicationType) {
                             PublicationType.IVY -> "ivy-publish"
                             PublicationType.MAVEN -> "maven-publish"
-                            null -> error("Publication type for ${nexusRepo.name} must be set.")
                         }
                         plugins.withId(id) {
                             val initializeTask = rootProject.tasks.named<InitializeNexusStagingRepository>("initialize${nexusRepo.capitalizedName}StagingRepository")

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishPlugin.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishPlugin.kt
@@ -187,6 +187,7 @@ class NexusPublishPlugin : Plugin<Project> {
                         val id = when (publicationType) {
                             PublicationType.IVY -> "ivy-publish"
                             PublicationType.MAVEN -> "maven-publish"
+                            null -> error("Publication type for ${nexusRepo.name} must be set.")
                         }
                         plugins.withId(id) {
                             val initializeTask = rootProject.tasks.named<InitializeNexusStagingRepository>("initialize${nexusRepo.capitalizedName}StagingRepository")


### PR DESCRIPTION
Please squash when merging.

Fixes #228 by not running two Gradle tests of the same version.

See [performance impact](https://github.com/gradle-nexus/publish-plugin/issues/228#issuecomment-1634091691) (positive, at least on my machine 😅) in the related issue.

`org.gradle.parallel` parallelizes tasks between projects.
`org.gradle.configuration-cache` parallelizes tasks inside projects.
`maxParallelForks` parallelizes Test classes inside Test tasks.

This PR
* reduces maxParallelForks to 1 so that `compatTestSomeGradleVersion` cannot run two tests which have the same Gradle needs at the same time.
* enables configuration cache so that `compatTestGradle1` and `compatTestGradle2` can run in parallel.
* Migrated from direct task access to newer APIs in KGP to prevent this warning:
```
> Task :compileKotlin
kotlinOptions.freeCompilerArgs were changed on task :compileKotlin execution phase: -java-parameters, -Xjvm-default=all, -Xjsr305=strict, -Xsam-conversions=class, -XXLanguage:+DisableCompatibilityModeForNewInference,
 -XXLanguage:-TypeEnhancementImprovementsInStrictMode, -Xsuppress-version-warnings
This behaviour is deprecated and become an error in future releases!
Approximate place of modification at execution phase:
    Build_gradle$11$1$1$1.execute(build.gradle.kts:179)
    Build_gradle$11$1$1$1.execute(build.gradle.kts:176)
```

Enabling configuration cache has a side effect: this is printed to the console:
```
> Task :compileKotlin
w: ATTENTION!
This build uses unsafe internal compiler arguments:

-XXLanguage:+DisableCompatibilityModeForNewInference
-XXLanguage:-TypeEnhancementImprovementsInStrictMode

This mode is not recommended for production use,
as no stability/compatibility guarantees are given on
compiler or generated code. Use it at your own risk!
```
it looks scary, but there's a [bug](https://github.com/gradle/gradle/issues/25483) in Gradle kotlin-dsl plugin which means that `org.gradle.kotlin.dsl.plugins.dsl.ExperimentalCompilerWarningSilencer` is not in play when CC is used.