### PR TITLE
Breaking change: rename Tasks to have Task suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,8 +201,8 @@ By default, `initialize${repository.name.capitalize()}StagingRepository` task ad
 
 The description can be customized via:
 * `io.github.gradlenexus.publishplugin.NexusPublishExtension.getRepositoryDescription` property (default: `$group:$module:$version` of the root project)
-* `io.github.gradlenexus.publishplugin.InitializeNexusStagingRepository.repositoryDescription` property
-* `io.github.gradlenexus.publishplugin.FindStagingRepository.descriptionRegex` property (regex, default: `"\\b" + Regex.escape(repositoryDescription) + "(\\s|$)"`)
+* `io.github.gradlenexus.publishplugin.InitializeNexusStagingRepositoryTask.repositoryDescription` property
+* `io.github.gradlenexus.publishplugin.FindStagingRepositoryTask.descriptionRegex` property (regex, default: `"\\b" + Regex.escape(repositoryDescription) + "(\\s|$)"`)
 
 So the steps to publish and release in different Gradle invocations are:
 1. Publish the artifacts to the staging repository: `./gradlew publishToSonatype`

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/CloseNexusStagingRepositoryTask.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/CloseNexusStagingRepositoryTask.kt
@@ -19,7 +19,7 @@ package io.github.gradlenexus.publishplugin
 import io.github.gradlenexus.publishplugin.internal.StagingRepositoryTransitioner
 import org.gradle.api.tasks.options.Option
 
-abstract class CloseNexusStagingRepository : AbstractTransitionNexusStagingRepositoryTask() {
+abstract class CloseNexusStagingRepositoryTask : AbstractTransitionNexusStagingRepositoryTask() {
 
     @Option(option = "staging-repository-id", description = "staging repository id to close")
     fun setStagingRepositoryIdToClose(stagingRepositoryId: String) {

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/FindStagingRepositoryTask.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/FindStagingRepositoryTask.kt
@@ -62,7 +62,7 @@ abstract class FindStagingRepositoryTask : AbstractNexusStagingRepositoryTask() 
         registry.get()[repository.name] = descriptor
     }
 
-    // TODO: Duplication with InitializeNexusStagingRepository
+    // TODO: Duplication with InitializeNexusStagingRepositoryTask
     private fun determineStagingProfileId(repository: NexusRepository, client: NexusClient): String {
         var stagingProfileId = repository.stagingProfileId.orNull
         if (stagingProfileId == null) {

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/InitializeNexusStagingRepositoryTask.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/InitializeNexusStagingRepositoryTask.kt
@@ -18,16 +18,15 @@ package io.github.gradlenexus.publishplugin
 
 import io.github.gradlenexus.publishplugin.internal.InvalidatingStagingRepositoryDescriptorRegistry
 import io.github.gradlenexus.publishplugin.internal.NexusClient
+import okhttp3.HttpUrl
 import org.gradle.api.GradleException
-import org.gradle.api.Incubating
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 
-@Incubating
-abstract class FindStagingRepository : AbstractNexusStagingRepositoryTask() {
+abstract class InitializeNexusStagingRepositoryTask : AbstractNexusStagingRepositoryTask() {
 
     @get:Internal
     abstract val registry: Property<InvalidatingStagingRepositoryDescriptorRegistry>
@@ -36,33 +35,19 @@ abstract class FindStagingRepository : AbstractNexusStagingRepositoryTask() {
     @get:Input
     abstract val packageGroup: Property<String>
 
-    @get:Input
-    abstract val descriptionRegex: Property<String>
-
-    @get:Internal
-    abstract val stagingRepositoryId: Property<String>
-
-    init {
-        outputs.cacheIf("the task requests data from the external repository, so we don't want to cache it") {
-            false
-        }
-    }
-
     @TaskAction
-    fun findStagingRepository() {
+    fun createStagingRepo() {
         val repository = repository.get()
         val serverUrl = repository.nexusUrl.get()
         val client = NexusClient(serverUrl, repository.username.orNull, repository.password.orNull, clientTimeout.orNull, connectTimeout.orNull)
         val stagingProfileId = determineStagingProfileId(repository, client)
-        logger.info("Fetching staging repositories for {} at {}, stagingProfileId '{}'", repository.name, serverUrl, stagingProfileId)
-        val descriptionRegex = descriptionRegex.get()
-        val descriptor = client.findStagingRepository(stagingProfileId, Regex(descriptionRegex))
-        logger.lifecycle("Staging repository for {} at {}, stagingProfileId '{}', descriptionRegex '{}' is '{}'", repository.name, serverUrl, stagingProfileId, descriptionRegex, descriptor.stagingRepositoryId)
-        stagingRepositoryId.set(descriptor.stagingRepositoryId)
+        logger.info("Creating staging repository for {} at {}, stagingProfileId '{}'", repository.name, serverUrl, stagingProfileId)
+        val descriptor = client.createStagingRepository(stagingProfileId, repositoryDescription.get())
+        val consumerUrl = HttpUrl.get(serverUrl)!!.newBuilder().addEncodedPathSegments("repositories/${descriptor.stagingRepositoryId}/content/").build()
+        logger.lifecycle("Created staging repository '{}' at {}", descriptor.stagingRepositoryId, consumerUrl)
         registry.get()[repository.name] = descriptor
     }
 
-    // TODO: Duplication with InitializeNexusStagingRepository
     private fun determineStagingProfileId(repository: NexusRepository, client: NexusClient): String {
         var stagingProfileId = repository.stagingProfileId.orNull
         if (stagingProfileId == null) {

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/InitializeNexusStagingRepositoryTask.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/InitializeNexusStagingRepositoryTask.kt
@@ -48,6 +48,7 @@ abstract class InitializeNexusStagingRepositoryTask : AbstractNexusStagingReposi
         registry.get()[repository.name] = descriptor
     }
 
+    // TODO: Duplication with FindStagingRepositoryTask
     private fun determineStagingProfileId(repository: NexusRepository, client: NexusClient): String {
         var stagingProfileId = repository.stagingProfileId.orNull
         if (stagingProfileId == null) {

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishPlugin.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishPlugin.kt
@@ -139,7 +139,7 @@ class NexusPublishPlugin : Plugin<Project> {
         registryProvider: Provider<InvalidatingStagingRepositoryDescriptorRegistry>
     ) {
         @Suppress("UNUSED_VARIABLE") // Keep it consistent.
-        val retrieveStagingProfileTask = tasks.register<RetrieveStagingProfile>(
+        val retrieveStagingProfileTask = tasks.register<RetrieveStagingProfileTask>(
             "retrieve${repo.capitalizedName}StagingProfile"
         ) {
             group = PublishingPlugin.PUBLISH_TASK_GROUP
@@ -149,7 +149,7 @@ class NexusPublishPlugin : Plugin<Project> {
             repository.convention(repo)
             packageGroup.convention(extension.packageGroup)
         }
-        val initializeTask = tasks.register<InitializeNexusStagingRepository>(
+        val initializeTask = tasks.register<InitializeNexusStagingRepositoryTask>(
             "initialize${repo.capitalizedName}StagingRepository"
         ) {
             group = PublishingPlugin.PUBLISH_TASK_GROUP
@@ -158,7 +158,7 @@ class NexusPublishPlugin : Plugin<Project> {
             repository.convention(repo)
             packageGroup.convention(extension.packageGroup)
         }
-        val findStagingRepository = tasks.register<FindStagingRepository>(
+        val findTask = tasks.register<FindStagingRepositoryTask>(
             "find${repo.capitalizedName}StagingRepository"
         ) {
             group = PublishingPlugin.PUBLISH_TASK_GROUP
@@ -168,14 +168,14 @@ class NexusPublishPlugin : Plugin<Project> {
             packageGroup.convention(extension.packageGroup)
             descriptionRegex.convention(extension.repositoryDescription.map { "\\b" + Regex.escape(it) + "(\\s|$)" })
         }
-        val closeTask = tasks.register<CloseNexusStagingRepository>(
+        val closeTask = tasks.register<CloseNexusStagingRepositoryTask>(
             "close${repo.capitalizedName}StagingRepository"
         ) {
             group = PublishingPlugin.PUBLISH_TASK_GROUP
             description = "Closes open staging repository in '${repo.name}' Nexus instance."
             repository.convention(repo)
         }
-        val releaseTask = tasks.register<ReleaseNexusStagingRepository>(
+        val releaseTask = tasks.register<ReleaseNexusStagingRepositoryTask>(
             "release${repo.capitalizedName}StagingRepository"
         ) {
             group = PublishingPlugin.PUBLISH_TASK_GROUP
@@ -191,11 +191,11 @@ class NexusPublishPlugin : Plugin<Project> {
 
         closeTask {
             mustRunAfter(initializeTask)
-            mustRunAfter(findStagingRepository)
+            mustRunAfter(findTask)
         }
         releaseTask {
             mustRunAfter(initializeTask)
-            mustRunAfter(findStagingRepository)
+            mustRunAfter(findTask)
             mustRunAfter(closeTask)
         }
         closeAndReleaseTask {
@@ -216,10 +216,10 @@ class NexusPublishPlugin : Plugin<Project> {
                             PublicationType.MAVEN -> "maven-publish"
                         }
                         plugins.withId(id) {
-                            val initializeTask = rootProject.tasks.named<InitializeNexusStagingRepository>("initialize${nexusRepo.capitalizedName}StagingRepository")
-                            val findStagingRepositoryTask = rootProject.tasks.named<FindStagingRepository>("find${nexusRepo.capitalizedName}StagingRepository")
-                            val closeTask = rootProject.tasks.named<CloseNexusStagingRepository>("close${nexusRepo.capitalizedName}StagingRepository")
-                            val releaseTask = rootProject.tasks.named<ReleaseNexusStagingRepository>("release${nexusRepo.capitalizedName}StagingRepository")
+                            val initializeTask = rootProject.tasks.named<InitializeNexusStagingRepositoryTask>("initialize${nexusRepo.capitalizedName}StagingRepository")
+                            val findTask = rootProject.tasks.named<FindStagingRepositoryTask>("find${nexusRepo.capitalizedName}StagingRepository")
+                            val closeTask = rootProject.tasks.named<CloseNexusStagingRepositoryTask>("close${nexusRepo.capitalizedName}StagingRepository")
+                            val releaseTask = rootProject.tasks.named<ReleaseNexusStagingRepositoryTask>("release${nexusRepo.capitalizedName}StagingRepository")
                             val publishAllTask = publishingProject.tasks.register("publishTo${nexusRepo.capitalizedName}") {
                                 group = PublishingPlugin.PUBLISH_TASK_GROUP
                                 description = "Publishes all Maven/Ivy publications produced by this project to the '${nexusRepo.name}' Nexus repository."
@@ -230,7 +230,7 @@ class NexusPublishPlugin : Plugin<Project> {
                             releaseTask {
                                 mustRunAfter(publishAllTask)
                             }
-                            configureTaskDependencies(publishingProject, initializeTask, findStagingRepositoryTask, publishAllTask, closeTask, releaseTask, publicationRepo, publicationType)
+                            configureTaskDependencies(publishingProject, initializeTask, findTask, publishAllTask, closeTask, releaseTask, publicationRepo, publicationType)
                         }
                     }
                 }
@@ -288,11 +288,11 @@ class NexusPublishPlugin : Plugin<Project> {
 
     private fun configureTaskDependencies(
         project: Project,
-        initializeTask: TaskProvider<InitializeNexusStagingRepository>,
-        findStagingRepositoryTask: TaskProvider<FindStagingRepository>,
+        initializeTask: TaskProvider<InitializeNexusStagingRepositoryTask>,
+        findTask: TaskProvider<FindStagingRepositoryTask>,
         publishAllTask: TaskProvider<Task>,
-        closeTask: TaskProvider<CloseNexusStagingRepository>,
-        releaseTask: TaskProvider<ReleaseNexusStagingRepository>,
+        closeTask: TaskProvider<CloseNexusStagingRepositoryTask>,
+        releaseTask: TaskProvider<ReleaseNexusStagingRepositoryTask>,
         artifactRepo: ArtifactRepository,
         publicationType: PublicationType
     ) {
@@ -305,7 +305,7 @@ class NexusPublishPlugin : Plugin<Project> {
             )
             publishTask {
                 dependsOn(initializeTask)
-                mustRunAfter(findStagingRepositoryTask)
+                mustRunAfter(findTask)
                 doFirst {
                     if (artifactRepo is UrlArtifactRepository) {
                         logger.info("Uploading to {}", artifactRepo.url)

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/ReleaseNexusStagingRepositoryTask.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/ReleaseNexusStagingRepositoryTask.kt
@@ -19,7 +19,7 @@ package io.github.gradlenexus.publishplugin
 import io.github.gradlenexus.publishplugin.internal.StagingRepositoryTransitioner
 import org.gradle.api.tasks.options.Option
 
-abstract class ReleaseNexusStagingRepository : AbstractTransitionNexusStagingRepositoryTask() {
+abstract class ReleaseNexusStagingRepositoryTask : AbstractTransitionNexusStagingRepositoryTask() {
 
     @Option(option = "staging-repository-id", description = "staging repository id to release")
     fun setStagingRepositoryIdToRelease(stagingRepositoryId: String) {

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/RetrieveStagingProfileTask.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/RetrieveStagingProfileTask.kt
@@ -27,7 +27,7 @@ import org.gradle.api.tasks.TaskAction
  * Diagnostic task for retrieving the [NexusRepository.stagingProfileId] for the [packageGroup] from the provided [NexusRepository] and logging it
  */
 @Incubating
-abstract class RetrieveStagingProfile : AbstractNexusStagingRepositoryTask() {
+abstract class RetrieveStagingProfileTask : AbstractNexusStagingRepositoryTask() {
 
     @get:Input
     abstract val packageGroup: Property<String>


### PR DESCRIPTION
Planned 2.0 breaking change from https://github.com/gradle-nexus/publish-plugin/pull/242#discussion_r1257343249

E2E tests will fail because each has a reference to old names:
```
tasks.withType(io.github.gradlenexus.publishplugin.InitializeNexusStagingRepository).configureEach {
```

---

Raised as a draft, because I'm not fully sure this is worth the maintenance cost in the community (not much on GitHub, but we don't know the full scale of closed source):
 * https://github.com/search?q=%2F%28%3F-i%29%5CbRetrieveStagingProfile%5Cb%2F&type=code
 * https://github.com/search?q=%2F%28%3F-i%29%5CbFindStagingRepository%5Cb%2F&type=code
 * https://github.com/search?q=%2F%28%3F-i%29%5CbInitializeNexusStagingRepository%5Cb%2F&type=code
 * https://github.com/search?q=%2F%28%3F-i%29%5CbReleaseNexusStagingRepository%5Cb%2F&type=code
 * https://github.com/search?q=%2F%28%3F-i%29%5CbCloseNexusStagingRepository%5Cb%2F&type=code
