### PR TITLE
Make the artifact ID explicit rather than relying on implicit naming.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,7 @@ plugins {
     id("org.ajoberstar.stutter") version "0.7.2"
 }
 
+base { archivesName = "publish-plugin" }
 group = "io.github.gradle-nexus"
 version = "2.0.0-SNAPSHOT"
 
@@ -171,7 +172,6 @@ kotlin.target.compilations.configureEach {
     val usedKotlinVersion = @Suppress("DEPRECATION") KotlinVersion.KOTLIN_1_3
 
     compilerOptions.configure {
-        if (this@configureEach.name == "main") moduleName = "publish-plugin"
         // Gradle fully supports running on Java 8: https://docs.gradle.org/current/userguide/compatibility.html,
         // so we should allow users to do that too.
         jvmTarget = JvmTarget.fromTarget(JavaVersion.VERSION_1_8.toString())
@@ -267,7 +267,7 @@ publishing {
     publications {
         afterEvaluate {
             named<MavenPublication>("pluginMaven") {
-                artifactId = "publish-plugin"
+                artifactId = base.archivesName.get()
                 pom {
                     name = readableName
                     description = project.description

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -171,6 +171,7 @@ kotlin.target.compilations.configureEach {
     val usedKotlinVersion = @Suppress("DEPRECATION") KotlinVersion.KOTLIN_1_3
 
     compilerOptions.configure {
+        if (this@configureEach.name == "main") moduleName = "publish-plugin"
         // Gradle fully supports running on Java 8: https://docs.gradle.org/current/userguide/compatibility.html,
         // so we should allow users to do that too.
         jvmTarget = JvmTarget.fromTarget(JavaVersion.VERSION_1_8.toString())

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -266,6 +266,7 @@ publishing {
     publications {
         afterEvaluate {
             named<MavenPublication>("pluginMaven") {
+                artifactId = "publish-plugin"
                 pom {
                     name = readableName
                     description = project.description
@@ -292,4 +293,3 @@ publishing {
         }
     }
 }
-

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,6 +13,4 @@ gradleEnterprise {
     }
 }
 
-// this needs to stay this way since it's used as the plugin's artifact id
-// for generating the plugin marker
-rootProject.name = "publish-plugin"
+rootProject.name = "gradle-nexus-publish-plugin"


### PR DESCRIPTION
This allows naming the rootProject whatever we want. Improving developer experience in IDE for example.

**Before**:
![image](https://github.com/gradle-nexus/publish-plugin/assets/2906988/50979bb2-53b8-427e-adcf-3eb96a3fd84f)


**After**:
![image](https://github.com/gradle-nexus/publish-plugin/assets/2906988/3a01522d-ea7d-4ed8-a953-9c67d5064bc1)

![image](https://github.com/gradle-nexus/publish-plugin/assets/2906988/a3d482f4-4699-4c77-8a2e-4c50a3400ca3)

**Testing**: after this PR the binaries produced by `publishToMavenLocal` are exactly the same.

---

Note: by default this changes the Kotlin-mangled `internal` names:
![image](https://github.com/gradle-nexus/publish-plugin/assets/2906988/68f63cec-9a7e-4a69-a8c6-8abf7a3c3fa2)
but it's possible to set it https://github.com/gradle-nexus/publish-plugin/commit/2b2013eaa440e207846710390c3c3fac52d3c6a0