### PR TITLE
Proof of concept: Gradle 8.3

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,10 +5,21 @@ import org.gradle.initialization.IGradlePropertiesLoader.SYSTEM_PROJECT_PROPERTI
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
+buildscript {
+    configurations.classpath.get().dependencyConstraints.apply {
+        removeAll(filter { it.reason == "Pinned to the embedded Kotlin" }.toSet())
+    }
+    dependencies {
+        classpath(enforcedPlatform("org.jetbrains.kotlin:kotlin-bom:1.8.22"))
+    }
+}
+
 plugins {
     // Leave this version behind of the current Gradle version, on the level of Gradle 8.2.1.
     // See https://github.com/gradle/gradle/issues/25868 for more details.
     `kotlin-dsl` version "4.0.14"
+    // Last version of Kotlin Gradle Plugin to support Kotlin 1.3 back-compilation.
+    id("org.jetbrains.kotlin.jvm") version "1.8.22"
     id("com.gradle.plugin-publish") version "1.2.0"
     id("com.diffplug.spotless") version "6.20.0"
     id("com.github.johnrengelman.shadow") version "8.1.1"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,9 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
 plugins {
-    `kotlin-dsl`
+    // Leave this version behind of the current Gradle version, on the level of Gradle 8.2.1.
+    // See https://github.com/gradle/gradle/issues/25868 for more details.
+    `kotlin-dsl` version "4.0.14"
     id("com.gradle.plugin-publish") version "1.2.0"
     id("com.diffplug.spotless") version "6.20.0"
     id("com.github.johnrengelman.shadow") version "8.1.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=03ec176d388f2aa99defcadc3ac6adf8dd2bce5145a129659537c0874dea5ad1
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
+distributionSha256Sum=05d10c69f03ef1ed1569171e637fc1737828bceaf4bb4a1e87407a4a7d1c01e6
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-rc-1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/internal/StagingRepositoryTransitioner.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/internal/StagingRepositoryTransitioner.kt
@@ -59,7 +59,7 @@ class StagingRepositoryTransitioner(val nexusClient: NexusClient, val retrier: A
     private fun assertRepositoryInDesiredState(repository: StagingRepository, vararg desiredStates: StagingRepository.State) {
         if (repository.state !in desiredStates) {
             throw RepositoryTransitionException(
-                "Staging repository is not in desired state ${desiredStates.contentToString()}: $repository. It is unexpected. Please check " +
+                "Staging repository is not in desired state ${desiredStates.contentDeepToString()}: $repository. It is unexpected. Please check " +
                     "the Nexus logs using its web interface - it can be caused by validation rules violation (e.g. publishing artifacts with the " +
                     "same version again). If not, please report it to https://github.com/gradle-nexus/publish-plugin/issues/ with the '--info' logs."
             )


### PR DESCRIPTION
This will allow us to use Gradle 8.3+, but we'll have to live with the warning:

> Configure project :
This version of Gradle expects version '4.1.0' of the `kotlin-dsl` plugin but version '4.0.14' has been applied to root project 'publish-plugin'. Let Gradle control the version of `kotlin-dsl` by removing any explicit `kotlin-dsl` version constraints from your build logic.
WARNING: Unsupported Kotlin plugin version.
The `embedded-kotlin` and `kotlin-dsl` plugins rely on features of Kotlin `1.9.0` that might work differently than in the requested version `1.8.22`.
