### PR TITLE
Drop kotlin-dsl plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
 plugins {
-    kotlin("jvm") version "1.8.22"
+    id("org.jetbrains.kotlin.jvm") version "1.8.22"
     id("com.gradle.plugin-publish") version "1.2.1"
     id("com.diffplug.spotless") version "6.23.3"
     id("com.github.johnrengelman.shadow") version "8.1.1"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
 plugins {
-    `kotlin-dsl`
+    kotlin("jvm") version "1.8.22"
     id("com.gradle.plugin-publish") version "1.2.1"
     id("com.diffplug.spotless") version "6.23.3"
     id("com.github.johnrengelman.shadow") version "8.1.1"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -95,6 +95,8 @@ dependencies {
     // but we are running CI on Java 8 in .github/workflows/java-versions.yml.
     testImplementation("org.mockito:mockito-junit-jupiter:4.11.0")
     testImplementation("com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0")
+
+    testImplementation(gradleApi())
 }
 
 java {

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/DefaultNexusRepositoryContainer.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/DefaultNexusRepositoryContainer.kt
@@ -34,9 +34,9 @@ internal open class DefaultNexusRepositoryContainer @Inject constructor(
         sonatype(Action {})
 
     override fun sonatype(action: Action<in NexusRepository>): NexusRepository = create("sonatype") {
-        nexusUrl.set(URI.create("https://oss.sonatype.org/service/local/"))
-        snapshotRepositoryUrl.set(URI.create("https://oss.sonatype.org/content/repositories/snapshots/"))
-        action.execute(this)
+        it.nexusUrl.set(URI.create("https://oss.sonatype.org/service/local/"))
+        it.snapshotRepositoryUrl.set(URI.create("https://oss.sonatype.org/content/repositories/snapshots/"))
+        action.execute(it)
     }
 
     override fun configure(configureClosure: Closure<*>): NamedDomainObjectContainer<NexusRepository> =

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishExtension.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishExtension.kt
@@ -20,8 +20,6 @@ import org.gradle.api.Action
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Nested
-import org.gradle.kotlin.dsl.domainObjectContainer
-import org.gradle.kotlin.dsl.newInstance
 import java.time.Duration
 
 abstract class NexusPublishExtension(objects: ObjectFactory) {
@@ -48,8 +46,8 @@ abstract class NexusPublishExtension(objects: ObjectFactory) {
     }
 
     val repositories: NexusRepositoryContainer = objects.newInstance(
-        DefaultNexusRepositoryContainer::class,
-        objects.domainObjectContainer(NexusRepository::class)
+        DefaultNexusRepositoryContainer::class.java,
+        objects.domainObjectContainer(NexusRepository::class.java)
     )
 
     fun repositories(action: Action<in NexusRepositoryContainer>) {

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishPlugin.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishPlugin.kt
@@ -223,6 +223,7 @@ class NexusPublishPlugin : Plugin<Project> {
                         val id = when (publicationType) {
                             PublicationType.IVY -> "ivy-publish"
                             PublicationType.MAVEN -> "maven-publish"
+                            null -> error("Repo publication type must be \"ivy-publish\" or \"maven-publish\"")
                         }
                         publishingProject.plugins.withId(id) {
                             val initializeTask = rootProject.tasks.named("initialize${nexusRepo.capitalizedName}StagingRepository", InitializeNexusStagingRepository::class.java)

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishPlugin.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishPlugin.kt
@@ -170,7 +170,7 @@ class NexusPublishPlugin : Plugin<Project> {
             it.usesService(registryService)
             it.repository.convention(repo)
             it.packageGroup.convention(extension.packageGroup)
-            it.descriptionRegex.convention(extension.repositoryDescription.map { "\\b" + Regex.escape(it) + "(\\s|$)" })
+            it.descriptionRegex.convention(extension.repositoryDescription.map { repoDescription -> "\\b" + Regex.escape(repoDescription) + "(\\s|$)" })
         }
         val closeTask = tasks.register(
             "close${repo.capitalizedName}StagingRepository",
@@ -230,9 +230,9 @@ class NexusPublishPlugin : Plugin<Project> {
                             val findStagingRepositoryTask = rootProject.tasks.named("find${nexusRepo.capitalizedName}StagingRepository", FindStagingRepository::class.java)
                             val closeTask = rootProject.tasks.named("close${nexusRepo.capitalizedName}StagingRepository", CloseNexusStagingRepository::class.java)
                             val releaseTask = rootProject.tasks.named("release${nexusRepo.capitalizedName}StagingRepository", ReleaseNexusStagingRepository::class.java)
-                            val publishAllTask = publishingProject.tasks.register("publishTo${nexusRepo.capitalizedName}") {
-                                it.group = PublishingPlugin.PUBLISH_TASK_GROUP
-                                it.description = "Publishes all Maven/Ivy publications produced by this project to the '${nexusRepo.name}' Nexus repository."
+                            val publishAllTask = publishingProject.tasks.register("publishTo${nexusRepo.capitalizedName}") { task ->
+                                task.group = PublishingPlugin.PUBLISH_TASK_GROUP
+                                task.description = "Publishes all Maven/Ivy publications produced by this project to the '${nexusRepo.name}' Nexus repository."
                             }
                             closeTask.configure { task ->
                                 task.mustRunAfter(publishAllTask)
@@ -315,9 +315,9 @@ class NexusPublishPlugin : Plugin<Project> {
             publishTask.configure {
                 it.dependsOn(initializeTask)
                 it.mustRunAfter(findStagingRepositoryTask)
-                it.doFirst {
+                it.doFirst { task ->
                     if (artifactRepo is UrlArtifactRepository) {
-                        it.logger.info("Uploading to {}", artifactRepo.url)
+                        task.logger.info("Uploading to {}", artifactRepo.url)
                     }
                 }
             }
@@ -375,16 +375,16 @@ class NexusPublishPlugin : Plugin<Project> {
             extension.repositories.all {
                 val repositoryCapitalizedName = it.capitalizedName
                 val closeAndReleaseTask = rootProject.tasks.named("closeAndRelease${repositoryCapitalizedName}StagingRepository")
-                closeAndReleaseSimplifiedTask.configure {
-                    it.dependsOn(closeAndReleaseTask)
+                closeAndReleaseSimplifiedTask.configure { task ->
+                    task.dependsOn(closeAndReleaseTask)
                 }
                 val closeTask = rootProject.tasks.named("close${repositoryCapitalizedName}StagingRepository")
-                closeSimplifiedTask.configure {
-                    it.dependsOn(closeTask)
+                closeSimplifiedTask.configure { task ->
+                    task.dependsOn(closeTask)
                 }
                 val releaseTask = rootProject.tasks.named("release${repositoryCapitalizedName}StagingRepository")
-                releaseSimplifiedTask.configure {
-                    it.dependsOn(releaseTask)
+                releaseSimplifiedTask.configure { task ->
+                    task.dependsOn(releaseTask)
                 }
             }
         }

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishPlugin.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishPlugin.kt
@@ -395,17 +395,3 @@ private inline fun <reified T : Any> Project.theExtension(): T =
         this.extensions.findByType(it)
             ?: error("The plugin cannot be applied without the publishing plugin")
     }
-
-private fun <T> Provider<T>.forUseAtConfigurationTimeCompat(): Provider<T> =
-    if (GradleVersion.current() < GradleVersion.version("6.5")) {
-        // Gradle < 6.5 doesn't have this function.
-        this
-    } else if (GradleVersion.current() < GradleVersion.version("7.4")) {
-        // Gradle 6.5 - 7.3 requires this function to be called.
-        @Suppress("DEPRECATION")
-        this.forUseAtConfigurationTime()
-    } else {
-        // Gradle >= 7.4 deprecated this function in favor of not calling it (became no-op, and will eventually nag).
-        // https://docs.gradle.org/current/userguide/upgrading_version_7.html#for_use_at_configuration_time_deprecation
-        this
-    }

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusRepository.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusRepository.kt
@@ -29,7 +29,6 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import java.net.URI
-import kotlin.reflect.KClass
 
 abstract class NexusRepository(@Input val name: String) {
 

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusRepository.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusRepository.kt
@@ -65,8 +65,8 @@ abstract class NexusRepository(@Input val name: String) {
         ivyPatternLayout.set(action)
     }
 
-    enum class PublicationType(internal val gradleType: KClass<out Publication>, internal val publishTaskType: KClass<out DefaultTask>) {
-        MAVEN(MavenPublication::class, PublishToMavenRepository::class),
-        IVY(IvyPublication::class, PublishToIvyRepository::class)
+    enum class PublicationType(internal val gradleType: Class<out Publication>, internal val publishTaskType: Class<out DefaultTask>) {
+        MAVEN(MavenPublication::class.java, PublishToMavenRepository::class.java),
+        IVY(IvyPublication::class.java, PublishToIvyRepository::class.java)
     }
 }

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/internal/StagingRepositoryTransitioner.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/internal/StagingRepositoryTransitioner.kt
@@ -59,7 +59,7 @@ class StagingRepositoryTransitioner(val nexusClient: NexusClient, val retrier: A
     private fun assertRepositoryInDesiredState(repository: StagingRepository, vararg desiredStates: StagingRepository.State) {
         if (repository.state !in desiredStates) {
             throw RepositoryTransitionException(
-                "Staging repository is not in desired state ${desiredStates.contentToString()}: $repository. It is unexpected. Please check " +
+                "Staging repository is not in desired state ${desiredStates.contentDeepToString()}: $repository. It is unexpected. Please check " +
                     "the Nexus logs using its web interface - it can be caused by validation rules violation (e.g. publishing artifacts with the " +
                     "same version again). If not, please report it to https://github.com/gradle-nexus/publish-plugin/issues/ with the '--info' logs."
             )

--- a/src/test/kotlin/io/github/gradlenexus/publishplugin/TaskOrchestrationTest.kt
+++ b/src/test/kotlin/io/github/gradlenexus/publishplugin/TaskOrchestrationTest.kt
@@ -21,10 +21,6 @@ import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
-import org.gradle.kotlin.dsl.apply
-import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.create
-import org.gradle.kotlin.dsl.get
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Disabled
@@ -68,8 +64,8 @@ class TaskOrchestrationTest {
     internal fun `transitioning task should not run after non-related publish`(transitioningTaskName: String) {
         // given
         initSingleProjectWithDefaultConfiguration()
-        project.extensions.configure<NexusPublishExtension> {
-            repositories.create("myNexus")
+        project.extensions.configure(NexusPublishExtension::class.java) {
+            it.repositories.create("myNexus")
         }
         // expect
         assertGivenTaskMustNotRunAfterAnother(transitioningTaskName, "publishToMyNexus")
@@ -105,8 +101,8 @@ class TaskOrchestrationTest {
     )
     internal fun `simplified task without repository name should be available but trigger nothing if no repositories are configured`(simplifiedTaskName: String) {
         initSingleProjectWithDefaultConfiguration()
-        project.extensions.configure<NexusPublishExtension> {
-            repositories.clear()
+        project.extensions.configure(NexusPublishExtension::class.java) {
+            it.repositories.clear()
         }
 
         val simplifiedTasks = project.getTasksByName(simplifiedTaskName, true)
@@ -124,8 +120,8 @@ class TaskOrchestrationTest {
     )
     internal fun `simplified task without repository name should depend on all normal tasks (created one per defined repository)`(simplifiedTaskName: String, sonatypeTaskName: String, otherNexusTaskName: String) {
         initSingleProjectWithDefaultConfiguration()
-        project.extensions.configure<NexusPublishExtension> {
-            repositories.create("otherNexus")
+        project.extensions.configure(NexusPublishExtension::class.java) {
+            it.repositories.create("otherNexus")
         }
 
         val simplifiedTasks = getJustOneTaskByNameOrFail(simplifiedTaskName)
@@ -146,8 +142,8 @@ class TaskOrchestrationTest {
     )
     internal fun `description of simplified task contains names of all defined Nexus instances`(simplifiedTaskName: String) {
         initSingleProjectWithDefaultConfiguration()
-        project.extensions.configure<NexusPublishExtension> {
-            repositories.create("otherNexus")
+        project.extensions.configure(NexusPublishExtension::class.java) {
+            it.repositories.create("otherNexus")
         }
 
         val simplifiedTasks = getJustOneTaskByNameOrFail(simplifiedTaskName)
@@ -158,15 +154,15 @@ class TaskOrchestrationTest {
     }
 
     private fun initSingleProjectWithDefaultConfiguration() {
-        project.apply(plugin = "java")
-        project.apply(plugin = "maven-publish")
-        project.apply<NexusPublishPlugin>()
-        project.extensions.configure<NexusPublishExtension> {
-            repositories.sonatype()
+        project.pluginManager.apply("java")
+        project.pluginManager.apply("maven-publish")
+        project.pluginManager.apply(NexusPublishPlugin::class.java)
+        project.extensions.configure(NexusPublishExtension::class.java) {
+            it.repositories.sonatype()
         }
-        project.extensions.configure<PublishingExtension> {
-            publications.create<MavenPublication>("mavenJava") {
-                from(project.components["java"])
+        project.extensions.configure(PublishingExtension::class.java) {
+            it.publications.create("mavenJava", MavenPublication::class.java) { publication ->
+                publication.from(project.components.getByName("java"))
             }
         }
     }


### PR DESCRIPTION
Using the `kotlin-dsl` plugin creates additional implicit dependencies on the Kotlin version used by Gradle as seen in https://github.com/gradle-nexus/publish-plugin/pull/258#issue-1820712729.

Removing the use of kotlin-dsl in the plugin itself removes that dependency. Now the Kotlin version required by the project can be set independently and is not tied to the Kotlin version used by the Gradle version applied to the wrapper.