### PR TITLE
Simplify build file

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -170,33 +170,17 @@ sourceSets {
     }
 }
 
-// Supporting Gradle 6.2+ needs to use Kotlin 1.3.
-// See https://docs.gradle.org/current/userguide/compatibility.html
-// For future maintainer: Kotlin 1.9.0 dropped support for Kotlin 1.3, it'll only support 1.4+.
-// This means Gradle 7.0 will be the lowest supportable version for plugins.
-val usedKotlinVersion = @Suppress("DEPRECATION") KotlinVersion.KOTLIN_1_3
-
-kotlin.target.compilations.configureEach {
-    compileTaskProvider.configure {
-        // Validate that we're using the right version.
-        doFirst {
-            val api = compilerOptions.apiVersion.get()
-            val language = compilerOptions.languageVersion.get()
-            if (api != usedKotlinVersion || language != usedKotlinVersion) {
-                TODO(
-                    "There's mismatch between configured and actual versions:\n" +
-                            "apiVersion=${api}, languageVersion=${language}, configured=${usedKotlinVersion}."
-                )
-            }
-        }
-    }
-}
-
 tasks {
     withType<KotlinCompilationTask<*>>().configureEach {
         compilerOptions {
             // Suppress "Language version 1.3 is deprecated and its support will be removed in a future version of Kotlin".
             freeCompilerArgs.add("-Xsuppress-version-warnings")
+
+            // Supporting Gradle 6.2+ needs to use Kotlin 1.3.
+            // See https://docs.gradle.org/current/userguide/compatibility.html
+            // For future maintainer: Kotlin 1.9.0 dropped support for Kotlin 1.3, it'll only support 1.4+.
+            // This means Gradle 7.0 will be the lowest supportable version for plugins.
+            val usedKotlinVersion = @Suppress("DEPRECATION") KotlinVersion.KOTLIN_1_3
 
             apiVersion = usedKotlinVersion
             // Theoretically we could use newer language version here,

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ import org.jetbrains.gradle.ext.copyright
 import org.jetbrains.gradle.ext.settings
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import kotlin.math.min
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     id("org.jetbrains.kotlin.jvm") version "1.8.22"
@@ -103,8 +103,9 @@ dependencies {
     testImplementation(gradleApi())
 }
 
-kotlin {
-    jvmToolchain(8)
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 stutter {
@@ -171,8 +172,12 @@ sourceSets {
 }
 
 tasks {
-    withType<KotlinCompilationTask<*>>().configureEach {
+    withType<KotlinJvmCompile>().configureEach {
         compilerOptions {
+            // Gradle fully supports running on Java 8: https://docs.gradle.org/current/userguide/compatibility.html,
+            // so we should allow users to do that too.
+            jvmTarget = JvmTarget.JVM_1_8
+
             // Suppress "Language version 1.3 is deprecated and its support will be removed in a future version of Kotlin".
             freeCompilerArgs.add("-Xsuppress-version-warnings")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -102,9 +102,8 @@ dependencies {
     testImplementation(gradleApi())
 }
 
-java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+kotlin {
+    jvmToolchain(8)
 }
 
 stutter {
@@ -178,10 +177,6 @@ kotlin.target.compilations.configureEach {
     val usedKotlinVersion = @Suppress("DEPRECATION") KotlinVersion.KOTLIN_1_3
 
     compilerOptions.configure {
-        // Gradle fully supports running on Java 8: https://docs.gradle.org/current/userguide/compatibility.html,
-        // so we should allow users to do that too.
-        jvmTarget = JvmTarget.fromTarget(JavaVersion.VERSION_1_8.toString())
-
         // Suppress "Language version 1.3 is deprecated and its support will be removed in a future version of Kotlin".
         freeCompilerArgs.add("-Xsuppress-version-warnings")
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -146,7 +146,6 @@ val e2eTest: SourceSet by sourceSets.creating {
     runtimeClasspath += sourceSets["main"].output
 }
 
-@Suppress("UnstableApiUsage") // `configurations` container is incubating
 configurations {
     compatTestCompileClasspath {
         extendsFrom(testCompileClasspath.get())


### PR DESCRIPTION
Simplify the build file a bit by updating the way Kotlin API & language versions are declared, and how the JVM target is set.