### PR TITLE
Do not cache E2E tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -229,6 +229,7 @@ tasks {
         group = "Verification"
         testClassesDirs = e2eTest.output.classesDirs
         classpath = e2eTest.runtimeClasspath
+        outputs.doNotCacheIf("E2E tests verify the integration with external system") { true }
         // Pass E2E releasing properties to tests.
         // Prefer environment variables which are not displayed with --info
         // (unless non CI friendly properties with "." are used).


### PR DESCRIPTION
It can happen when executing e2e tests from cron on CI:
> Task :e2eTest FROM-CACHE

E.g. https://github.com/gradle-nexus/publish-plugin/actions/runs/7780393684/job/21213013841#step:6:34
