### PR TITLE
Allow applying the plugin to a non-root project

### DIFF
--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishExtension.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishExtension.kt
@@ -17,6 +17,7 @@
 package io.github.gradlenexus.publishplugin
 
 import org.gradle.api.Action
+import org.gradle.api.Incubating
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Nested
@@ -37,6 +38,9 @@ abstract class NexusPublishExtension(objects: ObjectFactory) {
     abstract val clientTimeout: Property<Duration>
 
     abstract val connectTimeout: Property<Duration>
+
+    @get:Incubating
+    abstract val independentProjects: Property<Boolean>
 
     @get:Nested
     abstract val transitionCheckOptions: TransitionCheckOptions

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/internal/StagingRepository.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/internal/StagingRepository.kt
@@ -16,7 +16,7 @@
 
 package io.github.gradlenexus.publishplugin.internal
 
-data class StagingRepository constructor(val id: String, val state: State, val transitioning: Boolean) {
+data class StagingRepository(val id: String, val state: State, val transitioning: Boolean) {
 
     enum class State {
         OPEN,


### PR DESCRIPTION
This introduces the idea of `independentProjects`, defaulting to false, and limiting application of the plugin to just the project applied to if it's true.

By itself, this change should allow projects with a single subproject (such as is templated by `gradle init`) to apply the plugin to that project only.  It's also laying a little ground-work for cross-project synchronisation of staging repositories that's compatible with isolated projects.

This PR is in response to #81 but is not a complete solution.