### PR TITLE
Switch GH actions to hash to mitigate version re-upload

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,17 +15,17 @@ jobs:
     steps:
 
     - name: Checkout project with submodules
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       with:
         submodules: true
 
     - name: Setup JDK
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 #4.7.0
       with:
         java-version: 11
         distribution: 'zulu'
 
-    - uses: gradle/actions/setup-gradle@v4
+    - uses: gradle/actions/setup-gradle@94baf225fe0a508e581a564467443d0e2379123b #v4.3.0
 
     - name: Run sanity check
       run: ./gradlew --stacktrace test

--- a/.github/workflows/gradle-latest-versions.yml
+++ b/.github/workflows/gradle-latest-versions.yml
@@ -10,14 +10,14 @@ jobs:
     name: "Compatibility tests with latest Gradle versions"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 #4.7.0
         with:
           java-version: 11
           distribution: 'zulu'
 
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@94baf225fe0a508e581a564467443d0e2379123b #v4.3.0
 
       - name: Fetch latest available Gradle versions
         run: |

--- a/.github/workflows/java-versions.yml
+++ b/.github/workflows/java-versions.yml
@@ -20,14 +20,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 #4.7.0
         with:
           java-version: ${{ matrix.jdk }}
           distribution: 'zulu'
 
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@94baf225fe0a508e581a564467443d0e2379123b #v4.3.0
 
       # Workaround https://github.com/ajoberstar/gradle-stutter/issues/22
       - name: Reduce number of Gradle regressions builds

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,14 +19,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
-    - uses: actions/setup-java@v4
+    - uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 #4.7.0
       with:
         java-version: 11
         distribution: 'zulu'
 
-    - uses: gradle/actions/setup-gradle@v4
+    - uses: gradle/actions/setup-gradle@94baf225fe0a508e581a564467443d0e2379123b #v4.3.0
 
     - name: "Build and Test"
       run: ./gradlew --stacktrace build compatTestJava11


### PR DESCRIPTION
Exact versions used (for verification in PR):
https://github.com/actions/checkout/commit/11bd71901bbe5b1630ceea73d27597364c9af683 https://github.com/actions/setup-java/commit/3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 https://github.com/gradle/actions/commit/94baf225fe0a508e581a564467443d0e2379123b

See:
https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/using-pre-written-building-blocks-in-your-workflow#using-shas