### PR TITLE
Remove duplicated sonatype repo definition in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,6 @@ In order to publish to Maven Central (aka the Central Repository or just Central
 ```groovy
 nexusPublishing {
     repositories {
-        sonatype()
-    }
-    repositories {
         // see https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#configuration
         sonatype {
             nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))


### PR DESCRIPTION
Given the upcoming OSSRH EOL/sunset and the number of users that will be migrating, it seems that this block can cause confusion. The `sonatype` definition is present twice, and will cause builds to fail with the follow error:

```
* What went wrong:
Cannot add a NexusRepository with name 'sonatype' as a NexusRepository with that name already exists.
```